### PR TITLE
Add Flask create_app() skeleton

### DIFF
--- a/jottit/__init__.py
+++ b/jottit/__init__.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from flask import Flask
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.route("/")
+    def index() -> str:
+        return "Jottit — modern port skeleton"
+
+    return app


### PR DESCRIPTION
Step toward #3: a minimal `create_app()` factory so subsequent PRs have something to register routes onto.

- `jottit/__init__.py` exposes `create_app() -> Flask`
- Single placeholder route at `/`
- Boots via `uv run flask --app jottit run`

No blueprints, no config, no DB yet — those land in the next PRs.