### PR TITLE
Wire up subdomain routing + root-domain blueprint

### DIFF
--- a/jottit/__init__.py
+++ b/jottit/__init__.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import os
+
 from flask import Flask
+from werkzeug.middleware.proxy_fix import ProxyFix
+
+from jottit.blueprints.root import root_bp
 
 
 def create_app() -> Flask:
-    app = Flask(__name__)
+    app = Flask(__name__, subdomain_matching=True)
+    app.config["SERVER_NAME"] = os.environ.get("JOTTIT_DOMAIN", "localhost:5000")
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)  # type: ignore[method-assign]
 
-    @app.route("/")
-    def index() -> str:
-        return "Jottit — modern port skeleton"
+    app.register_blueprint(root_bp)
 
     return app

--- a/jottit/blueprints/root.py
+++ b/jottit/blueprints/root.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from flask import Blueprint, request
+
+root_bp = Blueprint("root", __name__)
+
+
+@root_bp.route("/", methods=["GET", "POST"])
+def index() -> str:
+    return f"jottit:index {request.method} (TODO)"
+
+
+@root_bp.route("/sites", methods=["GET", "POST"])
+def sites() -> str:
+    return f"jottit:sites {request.method} (TODO)"
+
+
+@root_bp.route("/about")
+def about() -> str:
+    return "jottit:about (TODO)"
+
+
+@root_bp.route("/help")
+def help_page() -> str:
+    return "jottit:help (TODO)"
+
+
+@root_bp.route("/feedback", methods=["GET", "POST"])
+def feedback() -> str:
+    return f"jottit:feedback {request.method} (TODO)"


### PR DESCRIPTION
Step toward #3: turn the placeholder route into proper routing infrastructure.

## What's in this PR

- `jottit/__init__.py` — `create_app()` now:
  - Enables `subdomain_matching=True`
  - Reads `SERVER_NAME` from `$JOTTIT_DOMAIN` (default `localhost:5000`)
  - Wraps `wsgi_app` in `ProxyFix` (honors `X-Forwarded-*` from Fly's edge)
  - Registers the root-domain blueprint
- `jottit/blueprints/root.py` — root-domain blueprint with stubs for `/`, `/sites`, `/about`, `/help`, `/feedback` (matches the original `pages` registry from `dispatcher.py`).

## Course correction: subdomain_matching, not host_matching

Original plan called for `host_matching=True`. Flask's host_matching needs `host=` on every individual `@bp.route(...)` decorator — `register_blueprint(bp, host=…)` is silently ignored, and Blueprint() doesn't take a `host=` kwarg. `subdomain_matching=True` + `SERVER_NAME` gives identical `<slug>.<domain>` routing with `Blueprint(subdomain="<slug>")` doing the work at construction time. Same end result, much cleaner. Subdomain blueprints in the next PR will use this pattern.

## Verified

All 8 method/path combos return 200 with the expected stub text via Flask's test client. Requests to an unknown host return 404 (host-based isolation works). Ruff + pyright clean.