### PR TITLE
Add pytest infrastructure + GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Ruff lint
+        run: uv run ruff check jottit tests
+
+      - name: Ruff format check
+        run: uv run ruff format --check jottit tests
+
+      - name: Pyright
+        run: uv run pyright
+
+      - name: Pytest
+        run: uv run pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,4 +34,8 @@ ignore = ["E501"]
 [tool.pyright]
 pythonVersion = "3.12"
 typeCheckingMode = "standard"
-include = ["jottit"]
+include = ["jottit", "tests"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+
+from jottit import create_app
+
+
+@pytest.fixture
+def app() -> Iterator[Flask]:
+    app = create_app()
+    app.config.update(TESTING=True, SERVER_NAME="jottit.test")
+    yield app
+
+
+@pytest.fixture
+def client(app: Flask) -> Iterator[FlaskClient]:
+    with app.test_client() as c:
+        yield c

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+from flask.testing import FlaskClient
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "stub_prefix"),
+    [
+        ("GET", "/", b"jottit:index"),
+        ("POST", "/", b"jottit:index"),
+        ("GET", "/about", b"jottit:about"),
+        ("GET", "/help", b"jottit:help"),
+        ("GET", "/sites", b"jottit:sites"),
+        ("POST", "/sites", b"jottit:sites"),
+        ("GET", "/feedback", b"jottit:feedback"),
+        ("POST", "/feedback", b"jottit:feedback"),
+    ],
+)
+def test_root_routes_serve_stubs(
+    client: FlaskClient, method: str, path: str, stub_prefix: bytes
+) -> None:
+    response = client.open(path, method=method)
+    assert response.status_code == 200
+    assert response.data.startswith(stub_prefix)
+
+
+def test_unknown_host_returns_404(client: FlaskClient) -> None:
+    response = client.get("/", base_url="http://otherdomain.example/")
+    assert response.status_code == 404


### PR DESCRIPTION
Step toward #3 — set up the test harness before porting actual handlers, so every M2+ PR gets CI-gated automatically.

## What's in this PR

- **`tests/conftest.py`** — `app` and `client` fixtures backed by `create_app()` with `TESTING=True` and `SERVER_NAME=jottit.test` (deterministic, no `JOTTIT_DOMAIN` env-var dependency).
- **`tests/test_routing.py`** — 9 tests:
  - 8 parametrized cases covering every (method, path) combination on the root blueprint stubs
  - 1 test asserting unknown hosts return 404 (host-based isolation works)
- **`.github/workflows/ci.yml`** — runs `ruff check`, `ruff format --check`, `pyright`, and `pytest` on every PR and push to main, using `astral-sh/setup-uv@v8` with cache.
- **`pyproject.toml`** — `[tool.pytest.ini_options]` with `testpaths = ["tests"]` and `pythonpath = ["."]`; expand `pyright.include` to cover `tests/`.

## Test strategy

Two layers:

1. **Pure-function unit tests** — for things like `_normalize_postgres_url`, the spinner digest, the page-sort comparator, the markdown→sanitize pipeline. As we port them.
2. **HTTP-level integration tests via Flask's `test_client`** — the highest-ROI tests. They exercise routing + DB + templates + auth in one shot and are robust against internal refactors.

DB-backed fixtures (testcontainers-spawned Postgres, transaction-per-test rollback) land in the first M2 PR that touches the DB.

## Local verification

```
$ uv run ruff check jottit tests          # All checks passed!
$ uv run ruff format --check jottit tests # 6 files already formatted
$ uv run pyright                          # 0 errors, 0 warnings
$ uv run pytest -q                        # 9 passed in 0.01s
```