### PR TITLE
Add subdomain blueprints (site, admin, page) with stubs

### DIFF
--- a/jottit/__init__.py
+++ b/jottit/__init__.py
@@ -5,7 +5,10 @@ import os
 from flask import Flask
 from werkzeug.middleware.proxy_fix import ProxyFix
 
+from jottit.blueprints.admin import admin_bp
+from jottit.blueprints.page import page_bp
 from jottit.blueprints.root import root_bp
+from jottit.blueprints.site import site_bp
 
 
 def create_app() -> Flask:
@@ -14,5 +17,8 @@ def create_app() -> Flask:
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)  # type: ignore[method-assign]
 
     app.register_blueprint(root_bp)
+    app.register_blueprint(site_bp)
+    app.register_blueprint(admin_bp)
+    app.register_blueprint(page_bp)
 
     return app

--- a/jottit/blueprints/admin.py
+++ b/jottit/blueprints/admin.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from flask import Blueprint, request
+
+admin_bp = Blueprint("admin", __name__, subdomain="<site_slug>", url_prefix="/admin")
+
+
+@admin_bp.route("/settings", methods=["GET", "POST"])
+def settings(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/settings {request.method} (TODO)"
+
+
+@admin_bp.route("/design", methods=["GET", "POST"])
+def design(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/design {request.method} (TODO)"
+
+
+@admin_bp.route("/url-available", methods=["POST"])
+def url_available(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/url-available POST (TODO)"
+
+
+@admin_bp.route("/delete", methods=["GET", "POST"])
+def delete(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/delete {request.method} (TODO)"
+
+
+@admin_bp.route("/change-site-address", methods=["GET", "POST"])
+def change_site_address(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/change-site-address {request.method} (TODO)"
+
+
+@admin_bp.route("/change-password", methods=["GET", "POST"])
+def change_password(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/change-password {request.method} (TODO)"
+
+
+@admin_bp.route("/export")
+def export(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/export GET (TODO)"

--- a/jottit/blueprints/page.py
+++ b/jottit/blueprints/page.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from flask import Blueprint, request
+
+page_bp = Blueprint("page", __name__, subdomain="<site_slug>")
+
+
+@page_bp.route("/")
+def home(site_slug: str) -> str:
+    return f"page:{site_slug} home GET (TODO)"
+
+
+@page_bp.route("/<page_name>", methods=["GET", "POST"])
+def page(site_slug: str, page_name: str) -> str:
+    mode = request.args.get("m", "view")
+    return f"page:{site_slug} page={page_name} m={mode} {request.method} (TODO)"

--- a/jottit/blueprints/site.py
+++ b/jottit/blueprints/site.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from flask import Blueprint, request
+
+site_bp = Blueprint("site", __name__, subdomain="<site_slug>", url_prefix="/site")
+
+
+@site_bp.route("/claim", methods=["GET", "POST"])
+def claim(site_slug: str) -> str:
+    return f"site:{site_slug} site/claim {request.method} (TODO)"
+
+
+@site_bp.route("/signin", methods=["GET", "POST"])
+def signin(site_slug: str) -> str:
+    return f"site:{site_slug} site/signin {request.method} (TODO)"
+
+
+@site_bp.route("/signout", methods=["POST"])
+def signout(site_slug: str) -> str:
+    return f"site:{site_slug} site/signout POST (TODO)"
+
+
+@site_bp.route("/forgot-password", methods=["GET", "POST"])
+def forgot_password(site_slug: str) -> str:
+    return f"site:{site_slug} site/forgot-password {request.method} (TODO)"
+
+
+@site_bp.route("/change-password", methods=["GET", "POST"])
+def change_password(site_slug: str) -> str:
+    return f"site:{site_slug} site/change-password {request.method} (TODO)"
+
+
+@site_bp.route("/changes")
+def changes(site_slug: str) -> str:
+    return f"site:{site_slug} site/changes GET (TODO)"
+
+
+@site_bp.route("/changes.atom")
+def changes_atom(site_slug: str) -> str:
+    return f"site:{site_slug} site/changes.atom GET (TODO)"
+
+
+@site_bp.route("/hide-primer", methods=["POST"])
+def hide_primer(site_slug: str) -> str:
+    return f"site:{site_slug} site/hide-primer POST (TODO)"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -23,8 +23,3 @@ def test_root_routes_serve_stubs(
     response = client.open(path, method=method)
     assert response.status_code == 200
     assert response.data.startswith(stub_prefix)
-
-
-def test_unknown_host_returns_404(client: FlaskClient) -> None:
-    response = client.get("/", base_url="http://otherdomain.example/")
-    assert response.status_code == 404

--- a/tests/test_subdomain_routing.py
+++ b/tests/test_subdomain_routing.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import pytest
+from flask.testing import FlaskClient
+
+SITE_BASE = "http://mysite.jottit.test/"
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "expected_substring"),
+    [
+        ("GET", "/site/claim", "site/claim GET"),
+        ("POST", "/site/claim", "site/claim POST"),
+        ("GET", "/site/signin", "site/signin GET"),
+        ("POST", "/site/signin", "site/signin POST"),
+        ("POST", "/site/signout", "site/signout POST"),
+        ("GET", "/site/forgot-password", "site/forgot-password GET"),
+        ("POST", "/site/forgot-password", "site/forgot-password POST"),
+        ("GET", "/site/change-password", "site/change-password GET"),
+        ("POST", "/site/change-password", "site/change-password POST"),
+        ("GET", "/site/changes", "site/changes GET"),
+        ("GET", "/site/changes.atom", "site/changes.atom GET"),
+        ("POST", "/site/hide-primer", "site/hide-primer POST"),
+    ],
+)
+def test_site_blueprint(
+    client: FlaskClient, method: str, path: str, expected_substring: str
+) -> None:
+    response = client.open(path, method=method, base_url=SITE_BASE)
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert body.startswith("site:mysite ")
+    assert expected_substring in body
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "expected_substring"),
+    [
+        ("GET", "/admin/settings", "admin/settings GET"),
+        ("POST", "/admin/settings", "admin/settings POST"),
+        ("GET", "/admin/design", "admin/design GET"),
+        ("POST", "/admin/design", "admin/design POST"),
+        ("POST", "/admin/url-available", "admin/url-available POST"),
+        ("GET", "/admin/delete", "admin/delete GET"),
+        ("POST", "/admin/delete", "admin/delete POST"),
+        ("GET", "/admin/change-site-address", "admin/change-site-address GET"),
+        ("POST", "/admin/change-site-address", "admin/change-site-address POST"),
+        ("GET", "/admin/change-password", "admin/change-password GET"),
+        ("POST", "/admin/change-password", "admin/change-password POST"),
+        ("GET", "/admin/export", "admin/export GET"),
+    ],
+)
+def test_admin_blueprint(
+    client: FlaskClient, method: str, path: str, expected_substring: str
+) -> None:
+    response = client.open(path, method=method, base_url=SITE_BASE)
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert body.startswith("admin:mysite ")
+    assert expected_substring in body
+
+
+def test_page_blueprint_home(client: FlaskClient) -> None:
+    response = client.get("/", base_url=SITE_BASE)
+    assert response.status_code == 200
+    assert response.data.decode() == "page:mysite home GET (TODO)"
+
+
+@pytest.mark.parametrize("method", ["GET", "POST"])
+def test_page_blueprint_named_page(client: FlaskClient, method: str) -> None:
+    response = client.open("/about", method=method, base_url=SITE_BASE)
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert body == f"page:mysite page=about m=view {method} (TODO)"
+
+
+def test_page_blueprint_mode_query_param(client: FlaskClient) -> None:
+    response = client.get("/some-page?m=edit", base_url=SITE_BASE)
+    assert response.status_code == 200
+    assert "m=edit" in response.data.decode()
+
+
+def test_subdomain_slug_captured_per_request(client: FlaskClient) -> None:
+    r1 = client.get("/", base_url="http://alice.jottit.test/")
+    r2 = client.get("/", base_url="http://bob.jottit.test/")
+    assert "alice" in r1.data.decode()
+    assert "bob" in r2.data.decode()
+
+
+def test_root_blueprint_still_works_alongside_subdomains(client: FlaskClient) -> None:
+    response = client.get("/about", base_url="http://jottit.test/")
+    assert response.status_code == 200
+    assert response.data.decode() == "jottit:about (TODO)"


### PR DESCRIPTION
Step toward #3: register the three subdomain blueprints that mirror the `mode` classes from the original `dispatcher.py`.

## What's in this PR

Three Blueprints registered on `<site_slug>.<SERVER_NAME>`, each parallel to a mode class in the original code:

- **`site_bp`** — site-wide actions (claim, signin/out, password recovery, changes feed, hide-primer). 8 routes.
- **`admin_bp`** — admin actions (settings, design, URL availability, delete, change site address, change password, export). 7 routes.
- **`page_bp`** — `/` (home) and `/<page_name>` (with the original `?m=<mode>` query param selecting the action: view, edit, history, diff, etc.). 2 routes.

`site_slug` is captured as a URL variable on every route. Stubs return diagnostic strings so the tests can verify routing without DB dependencies.

## Tests

38 total now (up from 9). All subdomain routes exercised via `client.open(path, base_url="http://mysite.jottit.test/")`. Also verifies:
- Per-request slug capture (`alice.jottit.test` vs `bob.jottit.test`)
- Root blueprint still matches the apex domain alongside subdomains
- Query-param mode selection (`?m=edit`)

## Removed test

`test_unknown_host_returns_404` is gone. It worked in step 4 because no wildcard routes existed; now the `<site_slug>` subdomain converter matches any host (Werkzeug uses `<invalid>` as the fallback slug). Strict unknown-site → 404 belongs with the site resolver in the next step (when we actually look up the slug in the DB).

## Deferred

Draft endpoints (`POST_save`, `POST_delete`, `POST_recover_live_version`) — they live with page editing in M3, not here.