### PR TITLE
Add site resolver hook + .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Copy to .env for local development.
+
+# Base hostname the app serves. The bare hostname is the apex/marketing
+# surface; subdomains of it match site routes (`<slug>.<JOTTIT_DOMAIN>`).
+JOTTIT_DOMAIN=localhost:5000
+
+# Postgres. Fly emits `postgres://`; SQLAlchemy needs `postgresql+psycopg://`
+# (the make_engine factory normalizes either form).
+DATABASE_URL=postgresql+psycopg://jottit:jottit@localhost:5432/jottit
+
+# Flask session signing key. Required in production; anything random works locally.
+SECRET_KEY=dev-not-secret-replace-me
+
+# Cloudflare Turnstile keys (anti-spam on open-edit sites).
+# https://dash.cloudflare.com/?to=/:account/turnstile
+TURNSTILE_SITEKEY=
+TURNSTILE_SECRET=

--- a/jottit/__init__.py
+++ b/jottit/__init__.py
@@ -9,6 +9,7 @@ from jottit.blueprints.admin import admin_bp
 from jottit.blueprints.page import page_bp
 from jottit.blueprints.root import root_bp
 from jottit.blueprints.site import site_bp
+from jottit.site_resolver import resolve_site
 
 
 def create_app() -> Flask:
@@ -20,5 +21,7 @@ def create_app() -> Flask:
     app.register_blueprint(site_bp)
     app.register_blueprint(admin_bp)
     app.register_blueprint(page_bp)
+
+    app.before_request(resolve_site)
 
     return app

--- a/jottit/site_resolver.py
+++ b/jottit/site_resolver.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from flask import g, request
+
+
+def resolve_site() -> None:
+    """Stash site context on `flask.g` for the current request.
+
+    `g.site_slug` is the URL slug captured from a subdomain or path prefix,
+    or `None` on apex-domain routes.
+
+    `g.site` is the resolved site row, or `None`. The DB lookup is wired
+    once the engine is bound to the app.
+    """
+    g.site_slug = (request.view_args or {}).get("site_slug")
+    g.site = None

--- a/tests/test_site_resolver.py
+++ b/tests/test_site_resolver.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from flask import Flask, g, request
+
+from jottit.site_resolver import resolve_site
+
+
+def test_resolver_populates_site_slug_from_view_args(app: Flask) -> None:
+    with app.test_request_context("/"):
+        request.view_args = {"site_slug": "myblog"}
+        resolve_site()
+        assert g.site_slug == "myblog"
+        assert g.site is None
+
+
+def test_resolver_handles_none_view_args(app: Flask) -> None:
+    with app.test_request_context("/"):
+        request.view_args = None
+        resolve_site()
+        assert g.site_slug is None
+        assert g.site is None
+
+
+def test_resolver_handles_empty_view_args(app: Flask) -> None:
+    with app.test_request_context("/"):
+        request.view_args = {}
+        resolve_site()
+        assert g.site_slug is None
+        assert g.site is None
+
+
+def test_hook_runs_on_subdomain_request(app: Flask) -> None:
+    with app.test_request_context("/", base_url="http://blog.jottit.test/"):
+        app.preprocess_request()
+        assert g.site_slug == "blog"
+        assert g.site is None
+
+
+def test_hook_runs_on_apex_request(app: Flask) -> None:
+    with app.test_request_context("/about", base_url="http://jottit.test/"):
+        app.preprocess_request()
+        assert g.site_slug is None
+        assert g.site is None
+
+
+def test_hook_runs_on_admin_subdomain_route(app: Flask) -> None:
+    with app.test_request_context("/admin/settings", base_url="http://myblog.jottit.test/"):
+        app.preprocess_request()
+        assert g.site_slug == "myblog"


### PR DESCRIPTION
Step toward #3: install the request-time hook that future PRs will use to populate `flask.g` with site context.

## What's in this PR

- **`jottit/site_resolver.py`** — `resolve_site()` reads `request.view_args` (set by Flask's URL matching just before `before_request` hooks fire) and stashes:
  - `g.site_slug` — the slug captured by the `<site_slug>` URL converter on any subdomain or path-prefix route, or `None` on apex-domain routes
  - `g.site` — placeholder `None`. M2's first DB-using PR populates it with the actual site row (lookup by `public_url == site_slug` or `secret_url == site_slug`).
- **`jottit/__init__.py`** — `app.before_request(resolve_site)` registers the hook.
- **`.env.example`** — documents the env vars in scope across the port (only `JOTTIT_DOMAIN` is read today; the others get wired as we go).

## Tests (44 total now, was 38)

- 3 unit tests calling `resolve_site()` directly with synthetic `request.view_args` (None, `{}`, `{"site_slug": "x"}`)
- 3 integration tests using `app.preprocess_request()` to verify the hook fires correctly on real subdomain, apex, and admin-subdomain requests

## Scope split

Original step 6 was going to include both the resolver AND the **secret blueprint** (path-based `/<slug>/…` access on the apex domain for unclaimed sites). The secret blueprint adds ~17 stub routes parallel to `site_bp`/`admin_bp`/`page_bp` — meaningful new surface — and pairs naturally with the DB-backed site lookup. Splitting it into a separate step 7 keeps this PR focused on the hook foundation.