### PR TITLE
Add secret blueprint + extract view functions

### DIFF
--- a/jottit/__init__.py
+++ b/jottit/__init__.py
@@ -8,6 +8,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from jottit.blueprints.admin import admin_bp
 from jottit.blueprints.page import page_bp
 from jottit.blueprints.root import root_bp
+from jottit.blueprints.secret import secret_bp
 from jottit.blueprints.site import site_bp
 from jottit.site_resolver import resolve_site
 
@@ -21,6 +22,7 @@ def create_app() -> Flask:
     app.register_blueprint(site_bp)
     app.register_blueprint(admin_bp)
     app.register_blueprint(page_bp)
+    app.register_blueprint(secret_bp)
 
     app.before_request(resolve_site)
 

--- a/jottit/blueprints/admin.py
+++ b/jottit/blueprints/admin.py
@@ -1,40 +1,19 @@
 from __future__ import annotations
 
-from flask import Blueprint, request
+from flask import Blueprint
+
+from jottit.views import admin as views
 
 admin_bp = Blueprint("admin", __name__, subdomain="<site_slug>", url_prefix="/admin")
 
-
-@admin_bp.route("/settings", methods=["GET", "POST"])
-def settings(site_slug: str) -> str:
-    return f"admin:{site_slug} admin/settings {request.method} (TODO)"
-
-
-@admin_bp.route("/design", methods=["GET", "POST"])
-def design(site_slug: str) -> str:
-    return f"admin:{site_slug} admin/design {request.method} (TODO)"
-
-
-@admin_bp.route("/url-available", methods=["POST"])
-def url_available(site_slug: str) -> str:
-    return f"admin:{site_slug} admin/url-available POST (TODO)"
-
-
-@admin_bp.route("/delete", methods=["GET", "POST"])
-def delete(site_slug: str) -> str:
-    return f"admin:{site_slug} admin/delete {request.method} (TODO)"
-
-
-@admin_bp.route("/change-site-address", methods=["GET", "POST"])
-def change_site_address(site_slug: str) -> str:
-    return f"admin:{site_slug} admin/change-site-address {request.method} (TODO)"
-
-
-@admin_bp.route("/change-password", methods=["GET", "POST"])
-def change_password(site_slug: str) -> str:
-    return f"admin:{site_slug} admin/change-password {request.method} (TODO)"
-
-
-@admin_bp.route("/export")
-def export(site_slug: str) -> str:
-    return f"admin:{site_slug} admin/export GET (TODO)"
+admin_bp.add_url_rule("/settings", view_func=views.settings, methods=["GET", "POST"])
+admin_bp.add_url_rule("/design", view_func=views.design, methods=["GET", "POST"])
+admin_bp.add_url_rule("/url-available", view_func=views.url_available, methods=["POST"])
+admin_bp.add_url_rule("/delete", view_func=views.delete, methods=["GET", "POST"])
+admin_bp.add_url_rule(
+    "/change-site-address",
+    view_func=views.change_site_address,
+    methods=["GET", "POST"],
+)
+admin_bp.add_url_rule("/change-password", view_func=views.change_password, methods=["GET", "POST"])
+admin_bp.add_url_rule("/export", view_func=views.export)

--- a/jottit/blueprints/page.py
+++ b/jottit/blueprints/page.py
@@ -1,16 +1,10 @@
 from __future__ import annotations
 
-from flask import Blueprint, request
+from flask import Blueprint
+
+from jottit.views import page as views
 
 page_bp = Blueprint("page", __name__, subdomain="<site_slug>")
 
-
-@page_bp.route("/")
-def home(site_slug: str) -> str:
-    return f"page:{site_slug} home GET (TODO)"
-
-
-@page_bp.route("/<page_name>", methods=["GET", "POST"])
-def page(site_slug: str, page_name: str) -> str:
-    mode = request.args.get("m", "view")
-    return f"page:{site_slug} page={page_name} m={mode} {request.method} (TODO)"
+page_bp.add_url_rule("/", view_func=views.home)
+page_bp.add_url_rule("/<page_name>", view_func=views.view, methods=["GET", "POST"])

--- a/jottit/blueprints/secret.py
+++ b/jottit/blueprints/secret.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from flask import Blueprint
+
+from jottit.views import admin as admin_views
+from jottit.views import page as page_views
+from jottit.views import site as site_views
+
+secret_bp = Blueprint("secret", __name__, url_prefix="/<site_slug>")
+
+# Page
+secret_bp.add_url_rule("/", endpoint="page_home", view_func=page_views.home)
+secret_bp.add_url_rule(
+    "/<page_name>",
+    endpoint="page_view",
+    view_func=page_views.view,
+    methods=["GET", "POST"],
+)
+
+# Site
+secret_bp.add_url_rule(
+    "/site/claim", endpoint="site_claim", view_func=site_views.claim, methods=["GET", "POST"]
+)
+secret_bp.add_url_rule(
+    "/site/signin", endpoint="site_signin", view_func=site_views.signin, methods=["GET", "POST"]
+)
+secret_bp.add_url_rule(
+    "/site/signout", endpoint="site_signout", view_func=site_views.signout, methods=["POST"]
+)
+secret_bp.add_url_rule(
+    "/site/forgot-password",
+    endpoint="site_forgot_password",
+    view_func=site_views.forgot_password,
+    methods=["GET", "POST"],
+)
+secret_bp.add_url_rule(
+    "/site/change-password",
+    endpoint="site_change_password",
+    view_func=site_views.change_password,
+    methods=["GET", "POST"],
+)
+secret_bp.add_url_rule("/site/changes", endpoint="site_changes", view_func=site_views.changes)
+secret_bp.add_url_rule(
+    "/site/changes.atom",
+    endpoint="site_changes_atom",
+    view_func=site_views.changes_atom,
+)
+secret_bp.add_url_rule(
+    "/site/hide-primer",
+    endpoint="site_hide_primer",
+    view_func=site_views.hide_primer,
+    methods=["POST"],
+)
+
+# Admin
+secret_bp.add_url_rule(
+    "/admin/settings",
+    endpoint="admin_settings",
+    view_func=admin_views.settings,
+    methods=["GET", "POST"],
+)
+secret_bp.add_url_rule(
+    "/admin/design",
+    endpoint="admin_design",
+    view_func=admin_views.design,
+    methods=["GET", "POST"],
+)
+secret_bp.add_url_rule(
+    "/admin/url-available",
+    endpoint="admin_url_available",
+    view_func=admin_views.url_available,
+    methods=["POST"],
+)
+secret_bp.add_url_rule(
+    "/admin/delete",
+    endpoint="admin_delete",
+    view_func=admin_views.delete,
+    methods=["GET", "POST"],
+)
+secret_bp.add_url_rule(
+    "/admin/change-site-address",
+    endpoint="admin_change_site_address",
+    view_func=admin_views.change_site_address,
+    methods=["GET", "POST"],
+)
+secret_bp.add_url_rule(
+    "/admin/change-password",
+    endpoint="admin_change_password",
+    view_func=admin_views.change_password,
+    methods=["GET", "POST"],
+)
+secret_bp.add_url_rule("/admin/export", endpoint="admin_export", view_func=admin_views.export)

--- a/jottit/blueprints/site.py
+++ b/jottit/blueprints/site.py
@@ -1,45 +1,16 @@
 from __future__ import annotations
 
-from flask import Blueprint, request
+from flask import Blueprint
+
+from jottit.views import site as views
 
 site_bp = Blueprint("site", __name__, subdomain="<site_slug>", url_prefix="/site")
 
-
-@site_bp.route("/claim", methods=["GET", "POST"])
-def claim(site_slug: str) -> str:
-    return f"site:{site_slug} site/claim {request.method} (TODO)"
-
-
-@site_bp.route("/signin", methods=["GET", "POST"])
-def signin(site_slug: str) -> str:
-    return f"site:{site_slug} site/signin {request.method} (TODO)"
-
-
-@site_bp.route("/signout", methods=["POST"])
-def signout(site_slug: str) -> str:
-    return f"site:{site_slug} site/signout POST (TODO)"
-
-
-@site_bp.route("/forgot-password", methods=["GET", "POST"])
-def forgot_password(site_slug: str) -> str:
-    return f"site:{site_slug} site/forgot-password {request.method} (TODO)"
-
-
-@site_bp.route("/change-password", methods=["GET", "POST"])
-def change_password(site_slug: str) -> str:
-    return f"site:{site_slug} site/change-password {request.method} (TODO)"
-
-
-@site_bp.route("/changes")
-def changes(site_slug: str) -> str:
-    return f"site:{site_slug} site/changes GET (TODO)"
-
-
-@site_bp.route("/changes.atom")
-def changes_atom(site_slug: str) -> str:
-    return f"site:{site_slug} site/changes.atom GET (TODO)"
-
-
-@site_bp.route("/hide-primer", methods=["POST"])
-def hide_primer(site_slug: str) -> str:
-    return f"site:{site_slug} site/hide-primer POST (TODO)"
+site_bp.add_url_rule("/claim", view_func=views.claim, methods=["GET", "POST"])
+site_bp.add_url_rule("/signin", view_func=views.signin, methods=["GET", "POST"])
+site_bp.add_url_rule("/signout", view_func=views.signout, methods=["POST"])
+site_bp.add_url_rule("/forgot-password", view_func=views.forgot_password, methods=["GET", "POST"])
+site_bp.add_url_rule("/change-password", view_func=views.change_password, methods=["GET", "POST"])
+site_bp.add_url_rule("/changes", view_func=views.changes)
+site_bp.add_url_rule("/changes.atom", view_func=views.changes_atom)
+site_bp.add_url_rule("/hide-primer", view_func=views.hide_primer, methods=["POST"])

--- a/jottit/views/admin.py
+++ b/jottit/views/admin.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from flask import request
+
+
+def settings(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/settings {request.method} (TODO)"
+
+
+def design(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/design {request.method} (TODO)"
+
+
+def url_available(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/url-available POST (TODO)"
+
+
+def delete(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/delete {request.method} (TODO)"
+
+
+def change_site_address(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/change-site-address {request.method} (TODO)"
+
+
+def change_password(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/change-password {request.method} (TODO)"
+
+
+def export(site_slug: str) -> str:
+    return f"admin:{site_slug} admin/export GET (TODO)"

--- a/jottit/views/page.py
+++ b/jottit/views/page.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from flask import request
+
+
+def home(site_slug: str) -> str:
+    return f"page:{site_slug} home GET (TODO)"
+
+
+def view(site_slug: str, page_name: str) -> str:
+    mode = request.args.get("m", "view")
+    return f"page:{site_slug} page={page_name} m={mode} {request.method} (TODO)"

--- a/jottit/views/site.py
+++ b/jottit/views/site.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from flask import request
+
+
+def claim(site_slug: str) -> str:
+    return f"site:{site_slug} site/claim {request.method} (TODO)"
+
+
+def signin(site_slug: str) -> str:
+    return f"site:{site_slug} site/signin {request.method} (TODO)"
+
+
+def signout(site_slug: str) -> str:
+    return f"site:{site_slug} site/signout POST (TODO)"
+
+
+def forgot_password(site_slug: str) -> str:
+    return f"site:{site_slug} site/forgot-password {request.method} (TODO)"
+
+
+def change_password(site_slug: str) -> str:
+    return f"site:{site_slug} site/change-password {request.method} (TODO)"
+
+
+def changes(site_slug: str) -> str:
+    return f"site:{site_slug} site/changes GET (TODO)"
+
+
+def changes_atom(site_slug: str) -> str:
+    return f"site:{site_slug} site/changes.atom GET (TODO)"
+
+
+def hide_primer(site_slug: str) -> str:
+    return f"site:{site_slug} site/hide-primer POST (TODO)"

--- a/tests/test_secret_routing.py
+++ b/tests/test_secret_routing.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pytest
+from flask.testing import FlaskClient
+
+APEX = "http://jottit.test/"
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "expected_substring"),
+    [
+        ("GET", "/abc123/site/claim", "site/claim GET"),
+        ("POST", "/abc123/site/claim", "site/claim POST"),
+        ("GET", "/abc123/site/signin", "site/signin GET"),
+        ("POST", "/abc123/site/signin", "site/signin POST"),
+        ("POST", "/abc123/site/signout", "site/signout POST"),
+        ("GET", "/abc123/site/forgot-password", "site/forgot-password GET"),
+        ("POST", "/abc123/site/forgot-password", "site/forgot-password POST"),
+        ("GET", "/abc123/site/change-password", "site/change-password GET"),
+        ("POST", "/abc123/site/change-password", "site/change-password POST"),
+        ("GET", "/abc123/site/changes", "site/changes GET"),
+        ("GET", "/abc123/site/changes.atom", "site/changes.atom GET"),
+        ("POST", "/abc123/site/hide-primer", "site/hide-primer POST"),
+    ],
+)
+def test_secret_site_routes(
+    client: FlaskClient, method: str, path: str, expected_substring: str
+) -> None:
+    response = client.open(path, method=method, base_url=APEX)
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert body.startswith("site:abc123 ")
+    assert expected_substring in body
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "expected_substring"),
+    [
+        ("GET", "/abc123/admin/settings", "admin/settings GET"),
+        ("POST", "/abc123/admin/settings", "admin/settings POST"),
+        ("GET", "/abc123/admin/design", "admin/design GET"),
+        ("POST", "/abc123/admin/design", "admin/design POST"),
+        ("POST", "/abc123/admin/url-available", "admin/url-available POST"),
+        ("GET", "/abc123/admin/delete", "admin/delete GET"),
+        ("POST", "/abc123/admin/delete", "admin/delete POST"),
+        ("GET", "/abc123/admin/change-site-address", "admin/change-site-address GET"),
+        ("POST", "/abc123/admin/change-site-address", "admin/change-site-address POST"),
+        ("GET", "/abc123/admin/change-password", "admin/change-password GET"),
+        ("POST", "/abc123/admin/change-password", "admin/change-password POST"),
+        ("GET", "/abc123/admin/export", "admin/export GET"),
+    ],
+)
+def test_secret_admin_routes(
+    client: FlaskClient, method: str, path: str, expected_substring: str
+) -> None:
+    response = client.open(path, method=method, base_url=APEX)
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert body.startswith("admin:abc123 ")
+    assert expected_substring in body
+
+
+def test_secret_page_home(client: FlaskClient) -> None:
+    response = client.get("/abc123/", base_url=APEX)
+    assert response.status_code == 200
+    assert response.data.decode() == "page:abc123 home GET (TODO)"
+
+
+@pytest.mark.parametrize("method", ["GET", "POST"])
+def test_secret_page_named(client: FlaskClient, method: str) -> None:
+    response = client.open("/abc123/about", method=method, base_url=APEX)
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert body == f"page:abc123 page=about m=view {method} (TODO)"
+
+
+def test_secret_page_mode_query_param(client: FlaskClient) -> None:
+    response = client.get("/abc123/some-page?m=edit", base_url=APEX)
+    assert response.status_code == 200
+    assert "m=edit" in response.data.decode()
+
+
+@pytest.mark.parametrize(
+    ("secret_path", "subdomain_path"),
+    [
+        ("/abc123/", "/"),
+        ("/abc123/about", "/about"),
+        ("/abc123/site/claim", "/site/claim"),
+        ("/abc123/site/signin", "/site/signin"),
+        ("/abc123/admin/settings", "/admin/settings"),
+        ("/abc123/admin/design", "/admin/design"),
+    ],
+)
+def test_secret_and_subdomain_share_handler(
+    client: FlaskClient, secret_path: str, subdomain_path: str
+) -> None:
+    secret = client.get(secret_path, base_url=APEX)
+    subdomain = client.get(subdomain_path, base_url="http://abc123.jottit.test/")
+    assert secret.status_code == subdomain.status_code == 200
+    assert secret.data == subdomain.data
+
+
+def test_apex_static_routes_still_win_over_secret_prefix(client: FlaskClient) -> None:
+    # `/about` on the apex must hit root_bp.about, not secret_bp's
+    # `/<site_slug>/` with site_slug="about" (Flask prefers static over
+    # converter rules of the same length).
+    response = client.get("/about", base_url=APEX)
+    assert response.status_code == 200
+    assert response.data.decode() == "jottit:about (TODO)"


### PR DESCRIPTION
Final M1 step — closes out #3's M1 box: the routing skeleton is complete.

## Why both changes in one PR

Adding the secret blueprint by itself would duplicate every stub view function across two blueprint files. Refactoring view functions into a separate package without adding the secret blueprint would be a churny no-op. They belong together: the refactor *enables* the secret blueprint to register the same callables under a different URL pattern, eliminating the duplication before it starts.

## What's in this PR

**New directory `jottit/views/`** — pure view functions, no Flask Blueprint coupling:
- `views/site.py` — 8 stubs (claim, signin, signout, forgot_password, change_password, changes, changes_atom, hide_primer)
- `views/admin.py` — 7 stubs (settings, design, url_available, delete, change_site_address, change_password, export)
- `views/page.py` — 2 stubs (home, view)

**`jottit/blueprints/secret.py`** — registers every view above under `/<site_slug>/...` on the apex domain. `subdomain="<site_slug>"` from subdomain blueprints becomes `url_prefix="/<site_slug>"` here; the captured variable name is identical, so view functions don't care which path got them there.

**`jottit/blueprints/{site,admin,page}.py`** — now thin URL config files. Each is just `Blueprint(...)` + a series of `bp.add_url_rule(...)` calls pointing at the same view functions. No view bodies.

## The endpoint-collision detail

`site.change_password` and `admin.change_password` are two different view functions with the same `__name__`. In the subdomain blueprints they live in separate Blueprints, so the full endpoints (`site.change_password`, `admin.change_password`) don't collide. In `secret_bp`, they both want to register, and would both default to endpoint `secret.change_password` — Flask rejects that. Every `add_url_rule` in `secret.py` therefore passes an explicit prefixed `endpoint=` (`site_change_password`, `admin_change_password`, etc.).

## Tests (79 total, was 44)

- Every secret route exercised (`/abc123/site/claim`, `/abc123/admin/settings`, etc.) — 35 new tests
- **Parametrized parity test** verifying `client.get("/abc123/site/claim", base_url="http://jottit.test/")` and `client.get("/site/claim", base_url="http://abc123.jottit.test/")` return identical response bodies. This is the architecture promise: subdomain and secret access route to the same view function.
- Regression test that `/about` on the apex still hits `root_bp.about` rather than `secret_bp` with `site_slug="about"` (Flask prefers static rules over converter rules of the same length, but worth pinning down).