### PR TITLE
Port get_page and get_revision to SQLAlchemy Core

### DIFF
--- a/jottit/blueprints/page.py
+++ b/jottit/blueprints/page.py
@@ -2,9 +2,28 @@ from __future__ import annotations
 
 from flask import Blueprint
 
+from jottit.views import draft as draft_views
 from jottit.views import page as views
 
 page_bp = Blueprint("page", __name__, subdomain="<site_slug>")
 
 page_bp.add_url_rule("/", view_func=views.home, methods=["GET", "POST"])
+page_bp.add_url_rule(
+    "/draft/save",
+    endpoint="draft_save",
+    view_func=draft_views.save,
+    methods=["POST"],
+)
+page_bp.add_url_rule(
+    "/draft/cancel",
+    endpoint="draft_cancel",
+    view_func=draft_views.cancel,
+    methods=["POST"],
+)
+page_bp.add_url_rule(
+    "/draft/recover-live-version",
+    endpoint="draft_recover_live_version",
+    view_func=draft_views.recover_live_version,
+    methods=["POST"],
+)
 page_bp.add_url_rule("/<page_name>", view_func=views.view, methods=["GET", "POST"])

--- a/jottit/blueprints/page.py
+++ b/jottit/blueprints/page.py
@@ -6,5 +6,5 @@ from jottit.views import page as views
 
 page_bp = Blueprint("page", __name__, subdomain="<site_slug>")
 
-page_bp.add_url_rule("/", view_func=views.home)
+page_bp.add_url_rule("/", view_func=views.home, methods=["GET", "POST"])
 page_bp.add_url_rule("/<page_name>", view_func=views.view, methods=["GET", "POST"])

--- a/jottit/blueprints/secret.py
+++ b/jottit/blueprints/secret.py
@@ -9,7 +9,9 @@ from jottit.views import site as site_views
 secret_bp = Blueprint("secret", __name__, url_prefix="/<site_slug>")
 
 # Page
-secret_bp.add_url_rule("/", endpoint="page_home", view_func=page_views.home)
+secret_bp.add_url_rule(
+    "/", endpoint="page_home", view_func=page_views.home, methods=["GET", "POST"]
+)
 secret_bp.add_url_rule(
     "/<page_name>",
     endpoint="page_view",

--- a/jottit/blueprints/secret.py
+++ b/jottit/blueprints/secret.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from flask import Blueprint
 
 from jottit.views import admin as admin_views
+from jottit.views import draft as draft_views
 from jottit.views import page as page_views
 from jottit.views import site as site_views
 
@@ -11,6 +12,24 @@ secret_bp = Blueprint("secret", __name__, url_prefix="/<site_slug>")
 # Page
 secret_bp.add_url_rule(
     "/", endpoint="page_home", view_func=page_views.home, methods=["GET", "POST"]
+)
+secret_bp.add_url_rule(
+    "/draft/save",
+    endpoint="draft_save",
+    view_func=draft_views.save,
+    methods=["POST"],
+)
+secret_bp.add_url_rule(
+    "/draft/cancel",
+    endpoint="draft_cancel",
+    view_func=draft_views.cancel,
+    methods=["POST"],
+)
+secret_bp.add_url_rule(
+    "/draft/recover-live-version",
+    endpoint="draft_recover_live_version",
+    view_func=draft_views.recover_live_version,
+    methods=["POST"],
 )
 secret_bp.add_url_rule(
     "/<page_name>",

--- a/jottit/db.py
+++ b/jottit/db.py
@@ -417,9 +417,7 @@ def delete_draft(conn: Connection, *, page_id: int) -> None:
 
 
 def get_draft(conn: Connection, *, page_id: int) -> Row | None:
-    return conn.execute(
-        select(drafts).where(drafts.c.page_id == page_id).limit(1)
-    ).first()
+    return conn.execute(select(drafts).where(drafts.c.page_id == page_id).limit(1)).first()
 
 
 def new_draft(conn: Connection, *, page_id: int, content: str) -> None:
@@ -429,9 +427,7 @@ def new_draft(conn: Connection, *, page_id: int, content: str) -> None:
     on idle; subsequent saves replace the prior content instead of
     accumulating drafts.
     """
-    existing = conn.execute(
-        select(drafts.c.id).where(drafts.c.page_id == page_id)
-    ).first()
+    existing = conn.execute(select(drafts.c.id).where(drafts.c.page_id == page_id)).first()
     if existing is None:
         conn.execute(insert(drafts).values(page_id=page_id, content=content))
     else:

--- a/jottit/db.py
+++ b/jottit/db.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import difflib
 import random
 from dataclasses import dataclass
+from html import escape
 
 from flask import current_app, g
 from sqlalchemy import (
@@ -25,6 +27,9 @@ from sqlalchemy import (
     text,
     update,
 )
+from sqlalchemy import delete as sql_delete
+
+from jottit.diff import html2list
 
 metadata = MetaData()
 
@@ -260,33 +265,155 @@ def new_page(
     scroll_pos: int = 0,
     caret_pos: int = 0,
 ) -> int:
-    """Insert a page row plus its first revision (revision=1). Returns page_id.
-
-    Also updates `sites.updated` to the revision's created timestamp — Jottit
-    denormalizes "last activity" onto the site row to avoid joining to revisions
-    when listing sites by recency.
-    """
+    """Insert a page row plus its first revision (revision=1). Returns page_id."""
     page_id = conn.execute(
         insert(pages)
         .values(site_id=site_id, name=name, scroll_pos=scroll_pos, caret_pos=caret_pos)
         .returning(pages.c.id)
     ).scalar_one()
 
+    new_revision(
+        conn,
+        page_id=page_id,
+        revision=1,
+        content=content,
+        changes="<em>Created page</em>",
+        ip=ip,
+    )
+
+    return page_id
+
+
+def new_revision(
+    conn: Connection,
+    *,
+    page_id: int,
+    revision: int,
+    content: str,
+    changes: str | None,
+    ip: str | None = None,
+) -> None:
+    """Insert a revision and bump `sites.updated` to its created timestamp.
+
+    Jottit denormalizes "last activity" onto the site row to avoid joining to
+    revisions when listing sites by recency.
+    """
     revision_row = conn.execute(
         insert(revisions)
         .values(
             page_id=page_id,
-            revision=1,
+            revision=revision,
             content=content,
-            changes="<em>Created page</em>",
+            changes=changes,
             ip=ip,
         )
         .returning(revisions.c.created)
     ).one()
 
+    site_id = conn.execute(select(pages.c.site_id).where(pages.c.id == page_id)).scalar_one()
+
     conn.execute(update(sites).where(sites.c.id == site_id).values(updated=revision_row.created))
 
-    return page_id
+
+def update_caret_pos(
+    conn: Connection,
+    *,
+    page_id: int,
+    scroll_pos: int = 0,
+    caret_pos: int = 0,
+) -> None:
+    conn.execute(
+        update(pages)
+        .where(pages.c.id == page_id)
+        .values(scroll_pos=scroll_pos, caret_pos=caret_pos)
+    )
+
+
+def _format_changes(tokens: list[str], max_len: int = 40) -> str:
+    """Render a slice of html2list tokens as a quoted, escaped span snippet."""
+    s = " ".join(tokens).strip()
+    if len(s) > max_len:
+        s = s[:max_len].strip() + "..."
+    if not s:
+        return "whitespace"
+    return f'"<span class="src">{escape(s)}</span>"'
+
+
+def update_page(
+    conn: Connection,
+    *,
+    page_id: int,
+    content: str,
+    scroll_pos: int = 0,
+    caret_pos: int = 0,
+    ip: str | None = None,
+) -> None:
+    """Save a new revision if content changed, with a human-readable diff summary.
+
+    Also persists caret/scroll position and clears any draft. No-op on the
+    revision side when content matches the latest revision verbatim.
+    """
+    latest = get_revision(conn, page_id=page_id)
+    update_caret_pos(conn, page_id=page_id, scroll_pos=scroll_pos, caret_pos=caret_pos)
+    delete_draft(conn, page_id=page_id)
+
+    if latest is None or content == latest.content:
+        return
+
+    a = html2list(latest.content)
+    b = html2list(content)
+    matcher = difflib.SequenceMatcher(None, a, b)
+    changes = ""
+    for op, i1, i2, j1, j2 in matcher.get_opcodes():
+        if op == "equal":
+            continue
+        elif op == "replace":
+            changes = (
+                "Changed " + _format_changes(a[i1:i2], 20) + " to " + _format_changes(b[j1:j2], 20)
+            )
+        elif op == "delete":
+            changes = "Removed " + _format_changes(a[i1:i2])
+            break
+        elif op == "insert":
+            changes = "Added " + _format_changes(b[j1:j2])
+            break
+
+    new_revision(
+        conn,
+        page_id=page_id,
+        revision=latest.revision + 1,
+        content=content,
+        changes=changes,
+        ip=ip,
+    )
+
+
+def delete_page(conn: Connection, *, page_id: int, ip: str | None = None) -> None:
+    """Mark a page deleted and append a sentinel "page deleted" revision."""
+    latest = get_revision(conn, page_id=page_id)
+    next_revision = (latest.revision + 1) if latest is not None else 1
+    new_revision(
+        conn,
+        page_id=page_id,
+        revision=next_revision,
+        content="",
+        changes="<em>Page deleted.</em>",
+        ip=ip,
+    )
+    conn.execute(update(pages).where(pages.c.id == page_id).values(deleted=True))
+
+
+def undelete_page(conn: Connection, *, page_id: int, name: str) -> None:
+    """Restore a deleted page, also updating its name.
+
+    Jottit re-uses this path when the user deletes "foo" and re-creates it
+    as "Foo" — the underlying page is reused so prior revisions survive.
+    """
+    conn.execute(update(pages).where(pages.c.id == page_id).values(deleted=False, name=name))
+
+
+def delete_draft(conn: Connection, *, page_id: int) -> None:
+    conn.execute(sql_delete(drafts).where(drafts.c.page_id == page_id))
 
 
 def new_site(

--- a/jottit/db.py
+++ b/jottit/db.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     create_engine,
+    func,
     insert,
     or_,
     select,
@@ -209,6 +210,44 @@ def get_site(
         raise ValueError("get_site requires at least one of secret_url, public_url, site_id")
 
     return conn.execute(select(sites).where(*conditions)).first()
+
+
+def get_page(
+    conn: Connection,
+    *,
+    site_id: int,
+    page_name: str,
+) -> Row | None:
+    """Look up a page within a site by name (case-insensitive)."""
+    stmt = (
+        select(pages)
+        .where(
+            pages.c.site_id == site_id,
+            func.lower(pages.c.name) == page_name.lower(),
+        )
+        .limit(1)
+    )
+    return conn.execute(stmt).first()
+
+
+def get_revision(
+    conn: Connection,
+    *,
+    page_id: int,
+    revision: int | None = None,
+) -> Row | None:
+    """Return a specific revision (when `revision` is given) or the latest one.
+
+    Always filters to `revision > 0` for the latest case (mirrors the original;
+    revision 0 was reserved as a sentinel that's never actually inserted, but
+    the filter is kept for fidelity).
+    """
+    stmt = select(revisions).where(revisions.c.page_id == page_id)
+    if revision is not None:
+        stmt = stmt.where(revisions.c.revision == revision)
+    else:
+        stmt = stmt.where(revisions.c.revision > 0).order_by(revisions.c.revision.desc())
+    return conn.execute(stmt.limit(1)).first()
 
 
 def new_page(

--- a/jottit/db.py
+++ b/jottit/db.py
@@ -416,6 +416,28 @@ def delete_draft(conn: Connection, *, page_id: int) -> None:
     conn.execute(sql_delete(drafts).where(drafts.c.page_id == page_id))
 
 
+def get_draft(conn: Connection, *, page_id: int) -> Row | None:
+    return conn.execute(
+        select(drafts).where(drafts.c.page_id == page_id).limit(1)
+    ).first()
+
+
+def new_draft(conn: Connection, *, page_id: int, content: str) -> None:
+    """Upsert the single draft row for a page.
+
+    Each page has at most one in-flight draft — the editor JS autosaves
+    on idle; subsequent saves replace the prior content instead of
+    accumulating drafts.
+    """
+    existing = conn.execute(
+        select(drafts.c.id).where(drafts.c.page_id == page_id)
+    ).first()
+    if existing is None:
+        conn.execute(insert(drafts).values(page_id=page_id, content=content))
+    else:
+        conn.execute(update(drafts).where(drafts.c.page_id == page_id).values(content=content))
+
+
 def new_site(
     conn: Connection,
     *,

--- a/jottit/diff.py
+++ b/jottit/diff.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import difflib
+import re
+from html.parser import HTMLParser
+
+
+class _HTMLTokenizer(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.out: list[str] = []
+
+    def handle_data(self, data: str) -> None:
+        normalized = re.sub(r"\s+", " ", data)
+        self.out.extend(re.findall(r"[^\s]+", normalized))
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_str = "".join(f' {name}="{value}"' for name, value in attrs if value is not None)
+        self.out.append(f"<{tag}{attr_str}>")
+
+    def handle_endtag(self, tag: str) -> None:
+        self.out.append(f"</{tag}>")
+
+
+def html2list(text: str) -> list[str]:
+    """Tokenize HTML into words and tags, dropping whitespace runs."""
+    tokenizer = _HTMLTokenizer()
+    tokenizer.feed(text)
+    tokenizer.close()
+    return tokenizer.out
+
+
+def better_diff(a: str, b: str) -> str:
+    """Render an HTML diff of two strings using <ins>/<del> wrappers."""
+    a_tokens = html2list(a)
+    b_tokens = html2list(b)
+    matcher = difflib.SequenceMatcher(None, a_tokens, b_tokens)
+    parts: list[str] = []
+    for op, i1, i2, j1, j2 in matcher.get_opcodes():
+        if op == "equal":
+            parts.extend(b_tokens[j1:j2])
+        elif op == "delete":
+            parts.append("<del>" + " ".join(a_tokens[i1:i2]) + "</del>")
+        elif op == "insert":
+            parts.append("<ins>" + " ".join(b_tokens[j1:j2]) + "</ins>")
+        elif op == "replace":
+            parts.append("<del>" + " ".join(a_tokens[i1:i2]) + "</del>")
+            parts.append("<ins>" + " ".join(b_tokens[j1:j2]) + "</ins>")
+    return " ".join(parts)

--- a/jottit/render.py
+++ b/jottit/render.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import re
+from urllib.parse import quote
+
+import mistune
+import nh3
+
+# Backreference avoids matching escaped brackets: `\[[not a link]]`.
+_WIKILINK_RE = re.compile(r"(?<!\\)\[\[(.*?)(?:\|(.*?))?\]\]")
+
+# `escape=False` lets users embed raw HTML in markdown (the original used
+# markdown2's `markdown-in-html` extra). nh3 cleans the output before it
+# reaches the browser, so unsafe tags don't survive.
+_markdown = mistune.create_markdown(escape=False)
+
+
+def page_slug(name: str) -> str:
+    """URL slug for a page name: lowercased, spaces → underscores, percent-encoded."""
+    return quote(name.lower().replace(" ", "_"))
+
+
+def _wikify(html: str, *, site_root: str) -> str:
+    def mangle(match: re.Match[str]) -> str:
+        link = match.group(1)
+        anchor = match.group(2) or link
+        href = site_root if link.strip().lower() == "home" else site_root + page_slug(link)
+        return f'<a href="{href}" class="internal">{anchor}</a>'
+
+    return _WIKILINK_RE.sub(mangle, html)
+
+
+def format_content(text: str, *, site_root: str) -> str:
+    """Render page content (markdown + embedded HTML + wikilinks) as safe HTML.
+
+    `site_root` is the URL prefix that page names hang off (e.g. `/` for a
+    subdomain site, `/abc12/` for one accessed via its secret URL).
+
+    Wikilinks (`[[name]]` or `[[name|anchor]]`) run after sanitization so the
+    `class="internal"` marker we add isn't stripped. `[[home]]` is a special
+    case that links to the site root.
+    """
+    stripped = text.strip().lower()
+    if stripped.startswith("<html") and stripped.endswith("</html>"):
+        # Legacy passthrough: a page that's wholly HTML bypasses markdown
+        # rendering entirely. Inherited from the 2007 codebase — Jottit
+        # treats this as "the user knows what they're doing".
+        return text
+
+    html = _markdown(text)
+    assert isinstance(html, str)  # default HTML renderer always returns str
+    return _wikify(nh3.clean(html), site_root=site_root)

--- a/jottit/render.py
+++ b/jottit/render.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import re
-from urllib.parse import quote
 
 import mistune
 import nh3
+
+from jottit.urls import page_slug
 
 # Backreference avoids matching escaped brackets: `\[[not a link]]`.
 _WIKILINK_RE = re.compile(r"(?<!\\)\[\[(.*?)(?:\|(.*?))?\]\]")
@@ -13,11 +14,6 @@ _WIKILINK_RE = re.compile(r"(?<!\\)\[\[(.*?)(?:\|(.*?))?\]\]")
 # markdown2's `markdown-in-html` extra). nh3 cleans the output before it
 # reaches the browser, so unsafe tags don't survive.
 _markdown = mistune.create_markdown(escape=False)
-
-
-def page_slug(name: str) -> str:
-    """URL slug for a page name: lowercased, spaces → underscores, percent-encoded."""
-    return quote(name.lower().replace(" ", "_"))
 
 
 def _wikify(html: str, *, site_root: str) -> str:

--- a/jottit/templates/deleted.html
+++ b/jottit/templates/deleted.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Deleted</title>
+</head>
+<body>
+  <h1>This page has been deleted</h1>
+  <p>&ldquo;{{ page_name }}&rdquo; is gone. Append <code>?r=N</code> to view a specific revision.</p>
+</body>
+</html>

--- a/jottit/templates/edit_page.html
+++ b/jottit/templates/edit_page.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Edit: {{ page_name or "Home" }}</title>
+</head>
+<body>
+  <h1>Edit: {{ page_name or "Home" }}</h1>
+  <form method="post">
+    <input type="hidden" name="current_revision" value="{{ current_revision }}">
+    <p><textarea name="content" rows="20" cols="80">{{ content }}</textarea></p>
+    <p>
+      <button type="submit">Save</button>
+      {% if page_name %}<button type="submit" name="delete" value="1">Delete</button>{% endif %}
+    </p>
+  </form>
+</body>
+</html>

--- a/jottit/templates/notfound.html
+++ b/jottit/templates/notfound.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Not found</title>
+</head>
+<body>
+  <h1>Not found</h1>
+  <p>There's no page named &ldquo;{{ page_name }}&rdquo; on this site.</p>
+</body>
+</html>

--- a/jottit/templates/view_page.html
+++ b/jottit/templates/view_page.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{ page_name or "Home" }}</title>
+</head>
+<body>
+  <article>{{ content_html|safe }}</article>
+  <footer>
+    <small>revision {{ revision.revision }}</small>
+  </footer>
+</body>
+</html>

--- a/jottit/urls.py
+++ b/jottit/urls.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from urllib.parse import quote
+
+from flask import g, request
+
+
+def page_slug(name: str) -> str:
+    """URL slug for a page name: lowercased, spaces → underscores, percent-encoded."""
+    return quote(name.lower().replace(" ", "_"))
+
+
+def site_root() -> str:
+    """URL path prefix that page names hang off for the current request.
+
+    `/` for a subdomain site, `/<slug>/` for one accessed via its secret URL.
+    Wikilinks and post-save redirects both want this.
+    """
+    if request.blueprint == "secret":
+        return f"/{g.site_slug}/"
+    return "/"

--- a/jottit/views/draft.py
+++ b/jottit/views/draft.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from flask import abort, g, jsonify, request
+from flask.typing import ResponseReturnValue
+
+from jottit.db import (
+    delete_draft,
+    get_page,
+    get_request_conn,
+    get_revision,
+    new_draft,
+    update_caret_pos,
+)
+
+
+def save(site_slug: str) -> ResponseReturnValue:
+    """Autosave the editor's current textarea content as a draft."""
+    page = _resolve_page()
+    if page is None:
+        return "", 204
+
+    content = request.form.get("content", "")
+    new_draft(_conn(), page_id=page.id, content=content)
+    return "", 204
+
+
+def cancel(site_slug: str) -> ResponseReturnValue:
+    """Discard the current draft and persist the latest caret/scroll position."""
+    page = _resolve_page()
+    if page is None:
+        return "", 204
+
+    conn = _conn()
+    scroll_pos = request.form.get("scroll_pos", default=0, type=int)
+    caret_pos = request.form.get("caret_pos", default=0, type=int)
+    update_caret_pos(conn, page_id=page.id, scroll_pos=scroll_pos, caret_pos=caret_pos)
+    delete_draft(conn, page_id=page.id)
+    return "", 204
+
+
+def recover_live_version(site_slug: str) -> ResponseReturnValue:
+    """Drop the draft and return the latest saved revision's content as JSON.
+
+    The editor JS uses this when the user clicks "Revert to saved version":
+    server clears the draft, sends back the live content, the textarea
+    re-populates from it.
+    """
+    page = _resolve_page()
+    if page is None:
+        return jsonify(content="")
+
+    conn = _conn()
+    revision = get_revision(conn, page_id=page.id)
+    delete_draft(conn, page_id=page.id)
+    return jsonify(content=revision.content if revision is not None else "")
+
+
+def _conn():
+    conn = get_request_conn()
+    if conn is None:
+        abort(500)
+    return conn
+
+
+def _resolve_page():
+    if g.site is None:
+        abort(404)
+    page_name = request.form.get("page_name", "")
+    return get_page(_conn(), site_id=g.site.id, page_name=page_name)

--- a/jottit/views/page.py
+++ b/jottit/views/page.py
@@ -14,7 +14,8 @@ from jottit.db import (
     undelete_page,
     update_page,
 )
-from jottit.render import format_content, page_slug
+from jottit.render import format_content
+from jottit.urls import page_slug, site_root
 
 
 def home(site_slug: str) -> ResponseReturnValue:
@@ -55,7 +56,7 @@ def _render_view(conn: Connection, page_name: str) -> ResponseReturnValue:
     if revision is None:
         abort(404)
 
-    rendered = format_content(revision.content, site_root=_site_root())
+    rendered = format_content(revision.content, site_root=site_root())
     return render_template(
         "view_page.html",
         page_name=page_name,
@@ -143,10 +144,4 @@ def _normalize_line_endings(text: str) -> str:
 
 
 def _redirect_to(page_name: str) -> ResponseReturnValue:
-    return redirect(_site_root() + page_slug(page_name), code=303)
-
-
-def _site_root() -> str:
-    if request.blueprint == "secret":
-        return f"/{g.site_slug}/"
-    return "/"
+    return redirect(site_root() + page_slug(page_name), code=303)

--- a/jottit/views/page.py
+++ b/jottit/views/page.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
-from flask import abort, g, render_template, request
+from flask import abort, g, redirect, render_template, request
 from flask.typing import ResponseReturnValue
+from sqlalchemy import Connection
 
-from jottit.db import get_page, get_request_conn, get_revision
-from jottit.render import format_content
+from jottit.db import (
+    delete_page,
+    get_page,
+    get_request_conn,
+    get_revision,
+    new_page,
+    undelete_page,
+    update_page,
+)
+from jottit.render import format_content, page_slug
 
 
 def home(site_slug: str) -> ResponseReturnValue:
@@ -19,6 +28,16 @@ def view(site_slug: str, page_name: str) -> ResponseReturnValue:
     if conn is None:
         abort(500)
 
+    if request.method == "POST":
+        return _save_edit(conn, page_name)
+
+    if request.args.get("m") == "edit":
+        return _render_edit_form(conn, page_name)
+
+    return _render_view(conn, page_name)
+
+
+def _render_view(conn: Connection, page_name: str) -> ResponseReturnValue:
     page = get_page(conn, site_id=g.site.id, page_name=page_name)
     if page is None:
         return render_template("notfound.html", page_name=page_name), 404
@@ -38,6 +57,75 @@ def view(site_slug: str, page_name: str) -> ResponseReturnValue:
         revision=revision,
         content_html=rendered,
     )
+
+
+def _render_edit_form(conn: Connection, page_name: str) -> ResponseReturnValue:
+    page = get_page(conn, site_id=g.site.id, page_name=page_name)
+    if page is None:
+        return render_template(
+            "edit_page.html",
+            page_name=page_name,
+            content="",
+            current_revision=0,
+        )
+
+    revision = get_revision(conn, page_id=page.id)
+    return render_template(
+        "edit_page.html",
+        page_name=page_name,
+        content=revision.content if revision else "",
+        current_revision=revision.revision if revision else 0,
+    )
+
+
+def _save_edit(conn: Connection, page_name: str) -> ResponseReturnValue:
+    content = _normalize_line_endings(request.form.get("content", ""))
+    scroll_pos = request.form.get("scroll_pos", default=0, type=int)
+    caret_pos = request.form.get("caret_pos", default=0, type=int)
+    ip = request.remote_addr
+
+    page = get_page(conn, site_id=g.site.id, page_name=page_name)
+
+    # The Delete button submits the form with `delete=1`. Empty page_name
+    # is the home page, which can't be deleted.
+    if request.form.get("delete") and page_name:
+        if page is not None:
+            delete_page(conn, page_id=page.id, ip=ip)
+        return _redirect_to(page_name)
+
+    if page is None:
+        new_page(
+            conn,
+            site_id=g.site.id,
+            name=page_name,
+            content=content,
+            ip=ip,
+            scroll_pos=scroll_pos,
+            caret_pos=caret_pos,
+        )
+    else:
+        update_page(
+            conn,
+            page_id=page.id,
+            content=content,
+            scroll_pos=scroll_pos,
+            caret_pos=caret_pos,
+            ip=ip,
+        )
+        if page.deleted:
+            undelete_page(conn, page_id=page.id, name=page_name)
+
+    return _redirect_to(page_name)
+
+
+def _normalize_line_endings(text: str) -> str:
+    # Mirrors the original `re.sub(r'(\r\n|\r)', '\n', content)`: browsers
+    # post `\r\n` from <textarea>, but stored content uses `\n`.
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _redirect_to(page_name: str) -> ResponseReturnValue:
+    return redirect(_site_root() + page_slug(page_name), code=303)
 
 
 def _site_root() -> str:

--- a/jottit/views/page.py
+++ b/jottit/views/page.py
@@ -1,12 +1,46 @@
 from __future__ import annotations
 
-from flask import request
+from flask import abort, g, render_template, request
+from flask.typing import ResponseReturnValue
+
+from jottit.db import get_page, get_request_conn, get_revision
+from jottit.render import format_content
 
 
-def home(site_slug: str) -> str:
-    return f"page:{site_slug} home GET (TODO)"
+def home(site_slug: str) -> ResponseReturnValue:
+    return view(site_slug, "")
 
 
-def view(site_slug: str, page_name: str) -> str:
-    mode = request.args.get("m", "view")
-    return f"page:{site_slug} page={page_name} m={mode} {request.method} (TODO)"
+def view(site_slug: str, page_name: str) -> ResponseReturnValue:
+    if g.site is None:
+        abort(404)
+
+    conn = get_request_conn()
+    if conn is None:
+        abort(500)
+
+    page = get_page(conn, site_id=g.site.id, page_name=page_name)
+    if page is None:
+        return render_template("notfound.html", page_name=page_name), 404
+
+    requested_revision = request.args.get("r", type=int)
+    if page.deleted and requested_revision is None:
+        return render_template("deleted.html", page_name=page_name), 410
+
+    revision = get_revision(conn, page_id=page.id, revision=requested_revision)
+    if revision is None:
+        abort(404)
+
+    rendered = format_content(revision.content, site_root=_site_root())
+    return render_template(
+        "view_page.html",
+        page_name=page_name,
+        revision=revision,
+        content_html=rendered,
+    )
+
+
+def _site_root() -> str:
+    if request.blueprint == "secret":
+        return f"/{g.site_slug}/"
+    return "/"

--- a/jottit/views/page.py
+++ b/jottit/views/page.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from flask import abort, g, redirect, render_template, request
+from flask import abort, g, jsonify, redirect, render_template, request
 from flask.typing import ResponseReturnValue
 from sqlalchemy import Connection
 
 from jottit.db import (
     delete_page,
+    get_draft,
     get_page,
     get_request_conn,
     get_revision,
@@ -28,10 +29,14 @@ def view(site_slug: str, page_name: str) -> ResponseReturnValue:
     if conn is None:
         abort(500)
 
+    mode = request.args.get("m", "view")
+
     if request.method == "POST":
+        if mode == "current_revision":
+            return _current_revision(conn, page_name)
         return _save_edit(conn, page_name)
 
-    if request.args.get("m") == "edit":
+    if mode == "edit":
         return _render_edit_form(conn, page_name)
 
     return _render_view(conn, page_name)
@@ -70,12 +75,25 @@ def _render_edit_form(conn: Connection, page_name: str) -> ResponseReturnValue:
         )
 
     revision = get_revision(conn, page_id=page.id)
+    draft = get_draft(conn, page_id=page.id)
+    # A draft (autosaved from a prior edit session) takes precedence — that's
+    # the user's in-flight work that hasn't been published yet.
+    content = draft.content if draft is not None else (revision.content if revision else "")
     return render_template(
         "edit_page.html",
         page_name=page_name,
-        content=revision.content if revision else "",
+        content=content,
         current_revision=revision.revision if revision else 0,
     )
+
+
+def _current_revision(conn: Connection, page_name: str) -> ResponseReturnValue:
+    """JSON endpoint used by the editor to poll for concurrent edits."""
+    page = get_page(conn, site_id=g.site.id, page_name=page_name)
+    if page is None:
+        return jsonify(revision=None)
+    revision = get_revision(conn, page_id=page.id)
+    return jsonify(revision=revision.revision if revision is not None else None)
 
 
 def _save_edit(conn: Connection, page_name: str) -> ResponseReturnValue:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+include = ["jottit/**/*.py", "tests/**/*.py"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM", "RUF"]

--- a/tests/test_db_queries.py
+++ b/tests/test_db_queries.py
@@ -5,7 +5,10 @@ from sqlalchemy import Connection, select
 
 from jottit.db import (
     _AMBIGUOUS_CHARS,
+    delete_draft,
+    delete_page,
     designs,
+    drafts,
     get_page,
     get_revision,
     get_site,
@@ -13,6 +16,9 @@ from jottit.db import (
     new_site,
     pages,
     revisions,
+    undelete_page,
+    update_caret_pos,
+    update_page,
 )
 
 
@@ -194,3 +200,152 @@ def test_get_revision_no_revisions_returns_none(db_conn: Connection) -> None:
     ).scalar_one()
 
     assert get_revision(db_conn, page_id=page_id) is None
+
+
+# ---- update_caret_pos ----
+
+
+def test_update_caret_pos_persists_values(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="uc1")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    update_caret_pos(db_conn, page_id=page.id, scroll_pos=120, caret_pos=45)
+
+    refreshed = get_page(db_conn, site_id=site_id, page_name="")
+    assert refreshed is not None
+    assert refreshed.scroll_pos == 120
+    assert refreshed.caret_pos == 45
+
+
+# ---- update_page ----
+
+
+def test_update_page_creates_new_revision_when_content_changes(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="<p>hello</p>", secret_url="up1")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    update_page(db_conn, page_id=page.id, content="<p>hello world</p>")
+
+    latest = get_revision(db_conn, page_id=page.id)
+    assert latest is not None
+    assert latest.revision == 2
+    assert latest.content == "<p>hello world</p>"
+    assert latest.changes is not None
+    assert "Added" in latest.changes
+    assert "world" in latest.changes
+
+
+def test_update_page_noop_when_content_unchanged(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="same", secret_url="up2")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    update_page(db_conn, page_id=page.id, content="same")
+
+    latest = get_revision(db_conn, page_id=page.id)
+    assert latest is not None
+    assert latest.revision == 1
+
+
+def test_update_page_replace_summary(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="<p>hello world</p>", secret_url="up3")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    update_page(db_conn, page_id=page.id, content="<p>hello there</p>")
+
+    latest = get_revision(db_conn, page_id=page.id)
+    assert latest is not None
+    assert latest.changes is not None
+    assert "Changed" in latest.changes
+    assert "world" in latest.changes
+    assert "there" in latest.changes
+
+
+def test_update_page_clears_draft(db_conn: Connection) -> None:
+    from sqlalchemy import insert as sa_insert
+
+    site_id = new_site(db_conn, content="hi", secret_url="up4")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    db_conn.execute(sa_insert(drafts).values(page_id=page.id, content="draft text"))
+    assert db_conn.execute(select(drafts).where(drafts.c.page_id == page.id)).first() is not None
+
+    update_page(db_conn, page_id=page.id, content="hi changed")
+
+    assert db_conn.execute(select(drafts).where(drafts.c.page_id == page.id)).first() is None
+
+
+def test_update_page_updates_caret_and_scroll(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="up5")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    update_page(db_conn, page_id=page.id, content="hi changed", scroll_pos=80, caret_pos=10)
+
+    refreshed = get_page(db_conn, site_id=site_id, page_name="")
+    assert refreshed is not None
+    assert refreshed.scroll_pos == 80
+    assert refreshed.caret_pos == 10
+
+
+# ---- delete_page / undelete_page ----
+
+
+def test_delete_page_marks_deleted_and_records_revision(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="dp1")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    delete_page(db_conn, page_id=page.id)
+
+    deleted_row = db_conn.execute(select(pages).where(pages.c.id == page.id)).one()
+    assert deleted_row.deleted is True
+
+    latest = get_revision(db_conn, page_id=page.id)
+    assert latest is not None
+    assert latest.revision == 2
+    assert latest.content == ""
+    assert latest.changes == "<em>Page deleted.</em>"
+
+
+def test_undelete_page_restores_with_new_name(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="ud1")
+    new_page(db_conn, site_id=site_id, name="foo", content="x")
+    page = get_page(db_conn, site_id=site_id, page_name="foo")
+    assert page is not None
+
+    delete_page(db_conn, page_id=page.id)
+    undelete_page(db_conn, page_id=page.id, name="Foo")
+
+    refreshed = db_conn.execute(select(pages).where(pages.c.id == page.id)).one()
+    assert refreshed.deleted is False
+    assert refreshed.name == "Foo"
+
+
+# ---- delete_draft ----
+
+
+def test_delete_draft_removes_row(db_conn: Connection) -> None:
+    from sqlalchemy import insert as sa_insert
+
+    site_id = new_site(db_conn, content="hi", secret_url="dd1")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    db_conn.execute(sa_insert(drafts).values(page_id=page.id, content="wip"))
+
+    delete_draft(db_conn, page_id=page.id)
+
+    assert db_conn.execute(select(drafts).where(drafts.c.page_id == page.id)).first() is None
+
+
+def test_delete_draft_noop_when_absent(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="dd2")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    delete_draft(db_conn, page_id=page.id)  # should not raise

--- a/tests/test_db_queries.py
+++ b/tests/test_db_queries.py
@@ -6,7 +6,10 @@ from sqlalchemy import Connection, select
 from jottit.db import (
     _AMBIGUOUS_CHARS,
     designs,
+    get_page,
+    get_revision,
     get_site,
+    new_page,
     new_site,
     pages,
     revisions,
@@ -110,3 +113,84 @@ def test_new_site_empty_partner_stored_as_null(db_conn: Connection) -> None:
     row = get_site(db_conn, site_id=site_id)
     assert row is not None
     assert row.partner is None
+
+
+# ---- get_page ----
+
+
+def test_get_page_finds_home_after_new_site(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="gp1")
+
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+    assert page.site_id == site_id
+    assert page.name == ""
+
+
+def test_get_page_is_case_insensitive(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="gp2")
+    new_page(db_conn, site_id=site_id, name="MyPage", content="x")
+
+    assert get_page(db_conn, site_id=site_id, page_name="MyPage") is not None
+    assert get_page(db_conn, site_id=site_id, page_name="mypage") is not None
+    assert get_page(db_conn, site_id=site_id, page_name="MYPAGE") is not None
+
+
+def test_get_page_missing_returns_none(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="gp3")
+
+    assert get_page(db_conn, site_id=site_id, page_name="nonexistent") is None
+
+
+def test_get_page_scoped_to_site(db_conn: Connection) -> None:
+    site_a = new_site(db_conn, content="a", secret_url="gp4a")
+    site_b = new_site(db_conn, content="b", secret_url="gp4b")
+    new_page(db_conn, site_id=site_a, name="shared", content="x")
+
+    assert get_page(db_conn, site_id=site_a, page_name="shared") is not None
+    assert get_page(db_conn, site_id=site_b, page_name="shared") is None
+
+
+# ---- get_revision ----
+
+
+def test_get_revision_returns_latest_by_default(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="gr1")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    rev = get_revision(db_conn, page_id=page.id)
+    assert rev is not None
+    assert rev.revision == 1
+    assert rev.content == "hi"
+
+
+def test_get_revision_returns_specific_revision(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="gr2")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    rev = get_revision(db_conn, page_id=page.id, revision=1)
+    assert rev is not None
+    assert rev.revision == 1
+
+
+def test_get_revision_missing_returns_none(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="gr3")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    assert get_revision(db_conn, page_id=page.id, revision=999) is None
+
+
+def test_get_revision_no_revisions_returns_none(db_conn: Connection) -> None:
+    # Page rows can exist without revisions if someone bypasses new_page;
+    # the revision-only function should handle that cleanly.
+    from sqlalchemy import insert as sa_insert
+
+    site_id = new_site(db_conn, content="hi", secret_url="gr4")
+    page_id = db_conn.execute(
+        sa_insert(pages).values(site_id=site_id, name="orphan").returning(pages.c.id)
+    ).scalar_one()
+
+    assert get_revision(db_conn, page_id=page_id) is None

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from jottit.diff import better_diff, html2list
+
+
+def test_html2list_splits_words_and_drops_whitespace_runs() -> None:
+    assert html2list("hello   world") == ["hello", "world"]
+
+
+def test_html2list_emits_start_and_end_tags() -> None:
+    tokens = html2list("<p>hi</p>")
+    assert tokens == ["<p>", "hi", "</p>"]
+
+
+def test_html2list_preserves_tag_attributes() -> None:
+    tokens = html2list('<a href="/x">go</a>')
+    assert tokens == ['<a href="/x">', "go", "</a>"]
+
+
+def test_better_diff_equal_passes_through() -> None:
+    assert better_diff("hello world", "hello world") == "hello world"
+
+
+def test_better_diff_marks_inserts() -> None:
+    out = better_diff("hello", "hello world")
+    assert "<ins>world</ins>" in out
+    assert "hello" in out
+
+
+def test_better_diff_marks_deletes() -> None:
+    out = better_diff("hello world", "hello")
+    assert "<del>world</del>" in out
+
+
+def test_better_diff_marks_replacements() -> None:
+    out = better_diff("hello world", "hello there")
+    assert "<del>world</del>" in out
+    assert "<ins>there</ins>" in out

--- a/tests/test_draft.py
+++ b/tests/test_draft.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+
+import pytest
+from flask.testing import FlaskClient
+from sqlalchemy import Connection, Engine, select
+
+from jottit.db import (
+    drafts,
+    get_draft,
+    get_page,
+    metadata,
+    new_draft,
+    new_page,
+    new_site,
+)
+
+APEX = "http://jottit.test/"
+
+
+@pytest.fixture(autouse=True)
+def _truncate_tables(db_engine: Engine) -> Iterator[None]:
+    yield
+    with db_engine.begin() as conn:
+        for table in reversed(metadata.sorted_tables):
+            conn.execute(table.delete())
+
+
+# ---- db helpers ----
+
+
+def test_new_draft_inserts_when_absent(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="dr1")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    new_draft(db_conn, page_id=page.id, content="wip")
+
+    draft = get_draft(db_conn, page_id=page.id)
+    assert draft is not None
+    assert draft.content == "wip"
+
+
+def test_new_draft_updates_when_present(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="dr2")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    new_draft(db_conn, page_id=page.id, content="first")
+    new_draft(db_conn, page_id=page.id, content="second")
+
+    rows = db_conn.execute(select(drafts).where(drafts.c.page_id == page.id)).all()
+    assert len(rows) == 1
+    assert rows[0].content == "second"
+
+
+def test_get_draft_returns_none_when_absent(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="dr3")
+    page = get_page(db_conn, site_id=site_id, page_name="")
+    assert page is not None
+
+    assert get_draft(db_conn, page_id=page.id) is None
+
+
+# ---- /draft/save ----
+
+
+def test_draft_save_creates_draft(client: FlaskClient, db_engine: Engine) -> None:
+    with db_engine.begin() as conn:
+        site_id = new_site(conn, content="hi", secret_url="ds1", public_url="alpha")
+
+    response = client.post(
+        "/draft/save",
+        base_url="http://alpha.jottit.test/",
+        data={"page_name": "", "content": "draft body"},
+    )
+
+    assert response.status_code == 204
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        draft = get_draft(conn, page_id=page.id)
+        assert draft is not None
+        assert draft.content == "draft body"
+
+
+def test_draft_save_for_missing_page_is_noop(client: FlaskClient, db_engine: Engine) -> None:
+    with db_engine.begin() as conn:
+        new_site(conn, content="hi", secret_url="ds2", public_url="beta")
+
+    response = client.post(
+        "/draft/save",
+        base_url="http://beta.jottit.test/",
+        data={"page_name": "no-such-page", "content": "lost"},
+    )
+
+    assert response.status_code == 204
+
+
+# ---- /draft/cancel ----
+
+
+def test_draft_cancel_removes_draft_and_records_caret_pos(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    with db_engine.begin() as conn:
+        site_id = new_site(conn, content="hi", secret_url="dc1", public_url="gamma")
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        new_draft(conn, page_id=page.id, content="abandon")
+
+    response = client.post(
+        "/draft/cancel",
+        base_url="http://gamma.jottit.test/",
+        data={"page_name": "", "scroll_pos": "300", "caret_pos": "50"},
+    )
+
+    assert response.status_code == 204
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        assert get_draft(conn, page_id=page.id) is None
+        assert page.scroll_pos == 300
+        assert page.caret_pos == 50
+
+
+# ---- /draft/recover-live-version ----
+
+
+def test_draft_recover_returns_latest_revision_and_clears_draft(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    with db_engine.begin() as conn:
+        site_id = new_site(conn, content="live content", secret_url="dr4", public_url="delta")
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        new_draft(conn, page_id=page.id, content="some draft")
+
+    response = client.post(
+        "/draft/recover-live-version",
+        base_url="http://delta.jottit.test/",
+        data={"page_name": ""},
+    )
+
+    assert response.status_code == 200
+    payload = json.loads(response.data)
+    assert payload["content"] == "live content"
+
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        assert get_draft(conn, page_id=page.id) is None
+
+
+def test_draft_recover_for_missing_page_returns_empty_content(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    with db_engine.begin() as conn:
+        new_site(conn, content="hi", secret_url="dr5", public_url="epsilon")
+
+    response = client.post(
+        "/draft/recover-live-version",
+        base_url="http://epsilon.jottit.test/",
+        data={"page_name": "nope"},
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.data) == {"content": ""}
+
+
+# ---- edit form loads draft ----
+
+
+def test_edit_form_prefers_draft_over_revision_content(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    with db_engine.begin() as conn:
+        site_id = new_site(conn, content="live version", secret_url="ed1", public_url="zeta")
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        new_draft(conn, page_id=page.id, content="in-flight draft text")
+
+    response = client.get("/?m=edit", base_url="http://zeta.jottit.test/")
+
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert "in-flight draft text" in body
+    assert "live version" not in body
+
+
+# ---- POST ?m=current_revision ----
+
+
+def test_current_revision_returns_latest_revision_number(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    with db_engine.begin() as conn:
+        site_id = new_site(conn, content="v1", secret_url="cr1", public_url="eta")
+        new_page(conn, site_id=site_id, name="notes", content="notes v1")
+
+    response = client.post(
+        "/notes?m=current_revision",
+        base_url="http://eta.jottit.test/",
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.data) == {"revision": 1}
+
+
+def test_current_revision_for_missing_page_returns_null(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    with db_engine.begin() as conn:
+        new_site(conn, content="hi", secret_url="cr2", public_url="theta")
+
+    response = client.post(
+        "/no-such-page?m=current_revision",
+        base_url="http://theta.jottit.test/",
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.data) == {"revision": None}
+
+
+# ---- secret-URL routing ----
+
+
+def test_draft_save_under_secret_url(client: FlaskClient, db_engine: Engine) -> None:
+    with db_engine.begin() as conn:
+        site_id = new_site(conn, content="hi", secret_url="abc12")
+
+    response = client.post(
+        "/abc12/draft/save",
+        base_url=APEX,
+        data={"page_name": "", "content": "secret draft"},
+    )
+
+    assert response.status_code == 204
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        draft = get_draft(conn, page_id=page.id)
+        assert draft is not None
+        assert draft.content == "secret draft"

--- a/tests/test_page_edit.py
+++ b/tests/test_page_edit.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from flask.testing import FlaskClient
+from sqlalchemy import Engine
+
+from jottit.db import get_page, get_revision, metadata, new_page, new_site
+
+APEX = "http://jottit.test/"
+
+
+@pytest.fixture(autouse=True)
+def _truncate_tables(db_engine: Engine) -> Iterator[None]:
+    yield
+    with db_engine.begin() as conn:
+        for table in reversed(metadata.sorted_tables):
+            conn.execute(table.delete())
+
+
+def _seed_site(db_engine: Engine, *, secret_url: str, public_url: str | None = None) -> int:
+    with db_engine.begin() as conn:
+        return new_site(conn, content="seed", secret_url=secret_url, public_url=public_url)
+
+
+# ---- GET edit form ----
+
+
+def test_get_edit_renders_form_with_current_content(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="e1", public_url="alpha")
+
+    response = client.get("/?m=edit", base_url="http://alpha.jottit.test/")
+
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert "<textarea" in body
+    assert "seed" in body
+    assert 'name="current_revision"' in body
+    assert 'value="1"' in body
+
+
+def test_get_edit_for_missing_page_renders_empty_form(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="e2", public_url="beta")
+
+    response = client.get("/new-page?m=edit", base_url="http://beta.jottit.test/")
+
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert "<textarea" in body
+    assert 'value="0"' in body  # current_revision=0 for never-existed page
+
+
+def test_get_edit_for_existing_page_named_page(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="e3", public_url="gamma")
+    with db_engine.begin() as conn:
+        new_page(conn, site_id=site_id, name="notes", content="original")
+
+    response = client.get("/notes?m=edit", base_url="http://gamma.jottit.test/")
+
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert "original" in body
+
+
+# ---- POST save (existing page) ----
+
+
+def test_post_save_updates_existing_page_and_redirects(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_site(db_engine, secret_url="e4", public_url="delta")
+
+    response = client.post(
+        "/",
+        base_url="http://delta.jottit.test/",
+        data={"content": "updated body"},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"].endswith("/")
+
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        rev = get_revision(conn, page_id=page.id)
+        assert rev is not None
+        assert rev.content == "updated body"
+        assert rev.revision == 2
+
+
+def test_post_save_normalizes_crlf_to_lf(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="e5", public_url="epsilon")
+
+    client.post(
+        "/",
+        base_url="http://epsilon.jottit.test/",
+        data={"content": "line1\r\nline2\r\nline3"},
+    )
+
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        rev = get_revision(conn, page_id=page.id)
+        assert rev is not None
+        assert "\r" not in rev.content
+        assert rev.content == "line1\nline2\nline3"
+
+
+def test_post_save_records_scroll_and_caret_pos(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="e6", public_url="zeta")
+
+    client.post(
+        "/",
+        base_url="http://zeta.jottit.test/",
+        data={"content": "changed", "scroll_pos": "200", "caret_pos": "12"},
+    )
+
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        assert page.scroll_pos == 200
+        assert page.caret_pos == 12
+
+
+# ---- POST save (create-on-write) ----
+
+
+def test_post_create_new_page_on_save(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="e7", public_url="eta")
+
+    response = client.post(
+        "/brand-new",
+        base_url="http://eta.jottit.test/",
+        data={"content": "first version"},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"].endswith("/brand-new")
+
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="brand-new")
+        assert page is not None
+        rev = get_revision(conn, page_id=page.id)
+        assert rev is not None
+        assert rev.content == "first version"
+        assert rev.revision == 1
+
+
+def test_post_create_via_secret_url_redirects_under_prefix(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="abc12")
+
+    response = client.post(
+        "/abc12/notes",
+        base_url=APEX,
+        data={"content": "hi"},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/abc12/notes"
+
+
+# ---- POST delete ----
+
+
+def test_post_delete_marks_page_deleted(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="e8", public_url="theta")
+    with db_engine.begin() as conn:
+        new_page(conn, site_id=site_id, name="gone", content="bye")
+
+    response = client.post(
+        "/gone",
+        base_url="http://theta.jottit.test/",
+        data={"content": "", "delete": "1"},
+    )
+
+    assert response.status_code == 303
+
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="gone")
+        assert page is not None
+        assert page.deleted is True
+
+
+def test_post_delete_on_home_is_ignored(client: FlaskClient, db_engine: Engine) -> None:
+    """Home page can't be deleted — the original guarded on `if page_name`."""
+    site_id = _seed_site(db_engine, secret_url="e9", public_url="iota")
+
+    client.post(
+        "/",
+        base_url="http://iota.jottit.test/",
+        data={"content": "still here", "delete": "1"},
+    )
+
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        assert page.deleted is False
+        # Treated as a normal save: content updated.
+        rev = get_revision(conn, page_id=page.id)
+        assert rev is not None
+        assert rev.content == "still here"
+
+
+def test_post_save_undeletes_when_deleted_page_is_edited(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_site(db_engine, secret_url="e10", public_url="kappa")
+    with db_engine.begin() as conn:
+        new_page(conn, site_id=site_id, name="back", content="v1")
+        page = get_page(conn, site_id=site_id, page_name="back")
+        assert page is not None
+        from jottit.db import delete_page
+
+        delete_page(conn, page_id=page.id)
+
+    response = client.post(
+        "/back",
+        base_url="http://kappa.jottit.test/",
+        data={"content": "revived"},
+    )
+
+    assert response.status_code == 303
+
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="back")
+        assert page is not None
+        assert page.deleted is False
+
+
+# ---- Unresolved site ----
+
+
+def test_post_to_unresolved_site_returns_404(client: FlaskClient) -> None:
+    response = client.post(
+        "/",
+        base_url="http://nosite.jottit.test/",
+        data={"content": "ignored"},
+    )
+
+    assert response.status_code == 404

--- a/tests/test_page_edit.py
+++ b/tests/test_page_edit.py
@@ -27,9 +27,7 @@ def _seed_site(db_engine: Engine, *, secret_url: str, public_url: str | None = N
 # ---- GET edit form ----
 
 
-def test_get_edit_renders_form_with_current_content(
-    client: FlaskClient, db_engine: Engine
-) -> None:
+def test_get_edit_renders_form_with_current_content(client: FlaskClient, db_engine: Engine) -> None:
     _seed_site(db_engine, secret_url="e1", public_url="alpha")
 
     response = client.get("/?m=edit", base_url="http://alpha.jottit.test/")

--- a/tests/test_page_view.py
+++ b/tests/test_page_view.py
@@ -136,9 +136,7 @@ def test_home_via_secret_url_renders(client: FlaskClient, db_engine: Engine) -> 
     assert "secret hello" in response.data.decode()
 
 
-def test_wikilinks_resolve_against_secret_site_root(
-    client: FlaskClient, db_engine: Engine
-) -> None:
+def test_wikilinks_resolve_against_secret_site_root(client: FlaskClient, db_engine: Engine) -> None:
     _seed_site(db_engine, secret_url="abc34", content="see [[Notes]]")
 
     response = client.get("/abc34/", base_url=APEX)
@@ -147,9 +145,7 @@ def test_wikilinks_resolve_against_secret_site_root(
     assert 'href="/abc34/notes"' in response.data.decode()
 
 
-def test_wikilinks_resolve_against_subdomain_root(
-    client: FlaskClient, db_engine: Engine
-) -> None:
+def test_wikilinks_resolve_against_subdomain_root(client: FlaskClient, db_engine: Engine) -> None:
     _seed_site(db_engine, secret_url="s8", public_url="omega", content="see [[Notes]]")
 
     response = client.get("/", base_url="http://omega.jottit.test/")

--- a/tests/test_page_view.py
+++ b/tests/test_page_view.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from flask.testing import FlaskClient
+from sqlalchemy import Engine
+
+from jottit.db import delete_page, get_page, metadata, new_page, new_site, update_page
+
+APEX = "http://jottit.test/"
+
+
+@pytest.fixture(autouse=True)
+def _truncate_tables(db_engine: Engine) -> Iterator[None]:
+    """Each test starts against a clean DB; page-view tests commit through the engine."""
+    yield
+    with db_engine.begin() as conn:
+        for table in reversed(metadata.sorted_tables):
+            conn.execute(table.delete())
+
+
+def _seed_site(
+    db_engine: Engine, *, secret_url: str, public_url: str | None = None, content: str = "hello"
+) -> int:
+    with db_engine.begin() as conn:
+        return new_site(conn, content=content, secret_url=secret_url, public_url=public_url)
+
+
+# ---- subdomain routes ----
+
+
+def test_home_on_public_subdomain_renders_latest_revision(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="s1", public_url="alpha", content="**hi there**")
+
+    response = client.get("/", base_url="http://alpha.jottit.test/")
+
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert "<strong>hi there</strong>" in body
+    assert "revision 1" in body
+
+
+def test_named_page_renders_content(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="s2", public_url="beta")
+    with db_engine.begin() as conn:
+        new_page(conn, site_id=site_id, name="notes", content="# Notebook")
+
+    response = client.get("/notes", base_url="http://beta.jottit.test/")
+
+    assert response.status_code == 200
+    assert "<h1>Notebook</h1>" in response.data.decode()
+
+
+def test_missing_page_returns_404_with_template(client: FlaskClient, db_engine: Engine) -> None:
+    _seed_site(db_engine, secret_url="s3", public_url="gamma")
+
+    response = client.get("/no-such-page", base_url="http://gamma.jottit.test/")
+
+    assert response.status_code == 404
+    assert "no-such-page" in response.data.decode()
+
+
+def test_deleted_page_returns_410_without_revision_param(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_site(db_engine, secret_url="s4", public_url="delta")
+    with db_engine.begin() as conn:
+        new_page(conn, site_id=site_id, name="gone", content="bye")
+        page = get_page(conn, site_id=site_id, page_name="gone")
+        assert page is not None
+        delete_page(conn, page_id=page.id)
+
+    response = client.get("/gone", base_url="http://delta.jottit.test/")
+
+    assert response.status_code == 410
+    assert "deleted" in response.data.decode().lower()
+
+
+def test_deleted_page_serves_specific_revision_when_requested(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_site(db_engine, secret_url="s5", public_url="epsilon")
+    with db_engine.begin() as conn:
+        new_page(conn, site_id=site_id, name="ghost", content="original content")
+        page = get_page(conn, site_id=site_id, page_name="ghost")
+        assert page is not None
+        delete_page(conn, page_id=page.id)
+
+    response = client.get("/ghost?r=1", base_url="http://epsilon.jottit.test/")
+
+    assert response.status_code == 200
+    assert "original content" in response.data.decode()
+
+
+def test_specific_revision_returns_that_revision(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="s6", public_url="zeta", content="v1")
+    with db_engine.begin() as conn:
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        update_page(conn, page_id=page.id, content="v2")
+
+    r1 = client.get("/?r=1", base_url="http://zeta.jottit.test/")
+    r2 = client.get("/?r=2", base_url="http://zeta.jottit.test/")
+
+    assert "v1" in r1.data.decode()
+    assert "v2" in r2.data.decode()
+
+
+def test_unknown_revision_returns_404(client: FlaskClient, db_engine: Engine) -> None:
+    _seed_site(db_engine, secret_url="s7", public_url="eta")
+
+    response = client.get("/?r=99", base_url="http://eta.jottit.test/")
+
+    assert response.status_code == 404
+
+
+def test_request_for_unresolved_subdomain_returns_404(client: FlaskClient) -> None:
+    # No site seeded — resolver leaves g.site=None, view aborts 404.
+    response = client.get("/", base_url="http://nosite.jottit.test/")
+
+    assert response.status_code == 404
+
+
+# ---- secret-URL routes ----
+
+
+def test_home_via_secret_url_renders(client: FlaskClient, db_engine: Engine) -> None:
+    _seed_site(db_engine, secret_url="abc12", content="secret hello")
+
+    response = client.get("/abc12/", base_url=APEX)
+
+    assert response.status_code == 200
+    assert "secret hello" in response.data.decode()
+
+
+def test_wikilinks_resolve_against_secret_site_root(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="abc34", content="see [[Notes]]")
+
+    response = client.get("/abc34/", base_url=APEX)
+
+    assert response.status_code == 200
+    assert 'href="/abc34/notes"' in response.data.decode()
+
+
+def test_wikilinks_resolve_against_subdomain_root(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="s8", public_url="omega", content="see [[Notes]]")
+
+    response = client.get("/", base_url="http://omega.jottit.test/")
+
+    assert response.status_code == 200
+    assert 'href="/notes"' in response.data.decode()

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from jottit.render import format_content, page_slug
+
+# ---- page_slug ----
+
+
+def test_page_slug_lowercases_and_underscores_spaces() -> None:
+    assert page_slug("About Us") == "about_us"
+
+
+def test_page_slug_percent_encodes_unsafe_chars() -> None:
+    assert page_slug("café") == "caf%C3%A9"
+
+
+# ---- markdown ----
+
+
+def test_format_content_renders_bold() -> None:
+    out = format_content("**hi**", site_root="/")
+    assert "<strong>hi</strong>" in out
+
+
+def test_format_content_renders_headings() -> None:
+    out = format_content("# Title", site_root="/")
+    assert "<h1>Title</h1>" in out
+
+
+def test_format_content_strips_dangerous_tags() -> None:
+    out = format_content("<script>alert(1)</script>hello", site_root="/")
+    assert "<script>" not in out
+    assert "hello" in out
+
+
+def test_format_content_keeps_safe_html() -> None:
+    out = format_content("<p>hi <em>there</em></p>", site_root="/")
+    assert "<em>there</em>" in out
+
+
+# ---- wikilinks ----
+
+
+def test_wikilink_simple() -> None:
+    out = format_content("[[FooBar]]", site_root="/")
+    assert '<a href="/foobar" class="internal">FooBar</a>' in out
+
+
+def test_wikilink_with_anchor() -> None:
+    out = format_content("[[About Us|our team]]", site_root="/")
+    assert '<a href="/about_us" class="internal">our team</a>' in out
+
+
+def test_wikilink_home_points_to_site_root() -> None:
+    out = format_content("[[home]]", site_root="/abc12/")
+    assert '<a href="/abc12/" class="internal">home</a>' in out
+
+
+def test_wikilink_with_secret_url_site_root() -> None:
+    out = format_content("[[Notes]]", site_root="/abc12/")
+    assert 'href="/abc12/notes"' in out
+
+
+# ---- full-HTML passthrough ----
+
+
+def test_full_html_passthrough_bypasses_markdown_and_sanitize() -> None:
+    raw = "<html><body><script>x</script></body></html>"
+    out = format_content(raw, site_root="/")
+    assert out == raw

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,17 +1,6 @@
 from __future__ import annotations
 
-from jottit.render import format_content, page_slug
-
-# ---- page_slug ----
-
-
-def test_page_slug_lowercases_and_underscores_spaces() -> None:
-    assert page_slug("About Us") == "about_us"
-
-
-def test_page_slug_percent_encodes_unsafe_chars() -> None:
-    assert page_slug("café") == "caf%C3%A9"
-
+from jottit.render import format_content
 
 # ---- markdown ----
 

--- a/tests/test_secret_routing.py
+++ b/tests/test_secret_routing.py
@@ -60,31 +60,14 @@ def test_secret_admin_routes(
     assert expected_substring in body
 
 
-def test_secret_page_home(client: FlaskClient) -> None:
-    response = client.get("/abc123/", base_url=APEX)
-    assert response.status_code == 200
-    assert response.data.decode() == "page:abc123 home GET (TODO)"
-
-
-@pytest.mark.parametrize("method", ["GET", "POST"])
-def test_secret_page_named(client: FlaskClient, method: str) -> None:
-    response = client.open("/abc123/about", method=method, base_url=APEX)
-    assert response.status_code == 200
-    body = response.data.decode()
-    assert body == f"page:abc123 page=about m=view {method} (TODO)"
-
-
-def test_secret_page_mode_query_param(client: FlaskClient) -> None:
-    response = client.get("/abc123/some-page?m=edit", base_url=APEX)
-    assert response.status_code == 200
-    assert "m=edit" in response.data.decode()
+# Page routes via the secret blueprint are exercised end-to-end in
+# tests/test_page_view.py. The site/admin parity checks below exercise that
+# the secret and subdomain blueprints share the same handler functions.
 
 
 @pytest.mark.parametrize(
     ("secret_path", "subdomain_path"),
     [
-        ("/abc123/", "/"),
-        ("/abc123/about", "/about"),
         ("/abc123/site/claim", "/site/claim"),
         ("/abc123/site/signin", "/site/signin"),
         ("/abc123/admin/settings", "/admin/settings"),

--- a/tests/test_subdomain_routing.py
+++ b/tests/test_subdomain_routing.py
@@ -60,31 +60,7 @@ def test_admin_blueprint(
     assert expected_substring in body
 
 
-def test_page_blueprint_home(client: FlaskClient) -> None:
-    response = client.get("/", base_url=SITE_BASE)
-    assert response.status_code == 200
-    assert response.data.decode() == "page:mysite home GET (TODO)"
-
-
-@pytest.mark.parametrize("method", ["GET", "POST"])
-def test_page_blueprint_named_page(client: FlaskClient, method: str) -> None:
-    response = client.open("/about", method=method, base_url=SITE_BASE)
-    assert response.status_code == 200
-    body = response.data.decode()
-    assert body == f"page:mysite page=about m=view {method} (TODO)"
-
-
-def test_page_blueprint_mode_query_param(client: FlaskClient) -> None:
-    response = client.get("/some-page?m=edit", base_url=SITE_BASE)
-    assert response.status_code == 200
-    assert "m=edit" in response.data.decode()
-
-
-def test_subdomain_slug_captured_per_request(client: FlaskClient) -> None:
-    r1 = client.get("/", base_url="http://alice.jottit.test/")
-    r2 = client.get("/", base_url="http://bob.jottit.test/")
-    assert "alice" in r1.data.decode()
-    assert "bob" in r2.data.decode()
+# Page routes are exercised end-to-end in tests/test_page_view.py.
 
 
 def test_root_blueprint_still_works_alongside_subdomains(client: FlaskClient) -> None:

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from flask import Flask
+
+from jottit.urls import page_slug, site_root
+
+# ---- page_slug ----
+
+
+def test_page_slug_lowercases_and_underscores_spaces() -> None:
+    assert page_slug("About Us") == "about_us"
+
+
+def test_page_slug_percent_encodes_unsafe_chars() -> None:
+    assert page_slug("café") == "caf%C3%A9"
+
+
+def test_page_slug_empty_returns_empty() -> None:
+    assert page_slug("") == ""
+
+
+# ---- site_root ----
+
+
+def test_site_root_subdomain_returns_slash() -> None:
+    app = Flask(__name__)
+    with app.test_request_context("/"):
+        # No blueprint set (apex) → still `/`.
+        assert site_root() == "/"
+
+
+def test_site_root_secret_blueprint_returns_slug_prefix(app: Flask) -> None:
+    # Use the real app with the secret blueprint registered.
+    with app.test_request_context("/abc12/", base_url="http://jottit.test/"):
+        # Push the URL through routing so request.blueprint is set.
+        app.preprocess_request()
+        assert site_root() == "/abc12/"
+
+
+def test_site_root_subdomain_blueprint_returns_slash(app: Flask) -> None:
+    with app.test_request_context("/", base_url="http://alpha.jottit.test/"):
+        app.preprocess_request()
+        assert site_root() == "/"


### PR DESCRIPTION
First step toward M3 (#3) — read-only page DB helpers. The remaining M3 steps will use these as building blocks; they don't change any handler behavior on their own.

## What's in this PR

- **`get_page(conn, *, site_id, page_name)`** — case-insensitive lookup scoped to a site. Returns a SQLAlchemy `Row` for the `pages` table only.
- **`get_revision(conn, *, page_id, revision=None)`** — returns a specific revision when one is given, or the latest one (filtering `revision > 0` to match the original's sentinel convention).

## Departing from the original

The original `db.get_page` returned a merged `page+latest_revision` Storage with both sets of fields on one object. The split version is cleaner: callers that only need the page row (delete/undelete/existence check) skip the revision join; callers that need both call both. Future M3 handlers compose them.

## Tests (107 total, was 99)

- `get_page`: found / case-insensitive / missing / site-scoped (4 tests)
- `get_revision`: latest / specific revision / missing revision / page without any revisions (4 tests)

## Remaining M3 steps

| Step | What | PR shape |
|---|---|---|
| 1 | Read-only page helpers (this PR) | here |
| 2 | Write page helpers + port diff.py | bundled with step 1 in some future PR, or its own |
| 3 | Markdown pipeline (mistune + nh3 + wikilinks) | own PR |
| 4–6 | Page view + edit + draft handlers | bundled |

History/diff/revert/feeds stay in M6.