### PR TITLE
M4: Auth (sessions, claim, signin, password)

### DIFF
--- a/jottit/__init__.py
+++ b/jottit/__init__.py
@@ -17,6 +17,7 @@ from jottit.site_resolver import resolve_site
 def create_app() -> Flask:
     app = Flask(__name__, subdomain_matching=True)
     app.config["SERVER_NAME"] = os.environ.get("JOTTIT_DOMAIN", "localhost:5000")
+    app.config["SECRET_KEY"] = os.environ["SECRET_KEY"]
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)  # type: ignore[method-assign]
 
     database_url = os.environ.get("DATABASE_URL")

--- a/jottit/auth.py
+++ b/jottit/auth.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import secrets
 from typing import Any
+from urllib.parse import quote
 
 from argon2 import PasswordHasher
 from argon2.exceptions import InvalidHashError, VerifyMismatchError
-from flask import session
+from flask import abort, g, redirect, request, session
+from flask.typing import ResponseReturnValue
+
+from jottit.urls import site_root
 
 _hasher = PasswordHasher()
 
@@ -97,3 +101,38 @@ def is_action_allowed(*, site: Any, action: str) -> bool:
     if security == "public":
         return action == "view"
     return False
+
+
+def gate(action: str) -> ResponseReturnValue | None:
+    """Enforce `action` on `g.site` for the current request.
+
+    Returns `None` when the visitor may proceed; otherwise returns a
+    Response the caller should return immediately:
+    - GETs that need a login redirect to /site/signin with `return_to`
+      preserved so the visitor lands back where they were.
+    - POSTs (or anything other than GET) get a 401 — they're typically
+      JSON/AJAX endpoints where a redirect chain doesn't help.
+    """
+    if is_action_allowed(site=g.site, action=action):
+        return None
+    if request.method == "GET":
+        rel = _current_path_relative_to_site()
+        return redirect(
+            f"{site_root()}site/signin?return_to={quote(rel, safe='/?=&')}",
+            code=303,
+        )
+    abort(401)
+
+
+def _current_path_relative_to_site() -> str:
+    """The current request path+query stripped of the site_root prefix.
+
+    Used to build a `return_to` value that, after sign-in, gets
+    concatenated back onto site_root() — so the same physical URL works
+    for both subdomain and secret-URL sites.
+    """
+    path = request.path
+    root = site_root()
+    relative = path[len(root) :] if path.startswith(root) else path.lstrip("/")
+    query = request.query_string.decode("utf-8") if request.query_string else ""
+    return f"{relative}?{query}" if query else relative

--- a/jottit/auth.py
+++ b/jottit/auth.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import secrets
+
+from argon2 import PasswordHasher
+from argon2.exceptions import InvalidHashError, VerifyMismatchError
+
+_hasher = PasswordHasher()
+
+
+def hash_password(password: str) -> str:
+    """Argon2id hash of a site password, suitable for storing in `sites.password`."""
+    return _hasher.hash(password)
+
+
+def verify_password(password: str, stored_hash: str) -> bool:
+    """Return True if `password` matches `stored_hash`, False otherwise.
+
+    Argon2's `verify` raises on mismatch; this wrapper swallows the
+    expected exceptions so callers can just branch on the bool.
+    """
+    try:
+        _hasher.verify(stored_hash, password)
+    except (VerifyMismatchError, InvalidHashError):
+        return False
+    return True
+
+
+def generate_change_password_token() -> str:
+    """One-time URL-safe token emailed for the password-reset flow."""
+    return secrets.token_urlsafe(32)

--- a/jottit/auth.py
+++ b/jottit/auth.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import secrets
+from typing import Any
 
 from argon2 import PasswordHasher
 from argon2.exceptions import InvalidHashError, VerifyMismatchError
+from flask import session
 
 _hasher = PasswordHasher()
+
+_SESSION_KEY = "signed_in_sites"
+
+
+# ---- Password hashing ----
 
 
 def hash_password(password: str) -> str:
@@ -29,3 +36,64 @@ def verify_password(password: str, stored_hash: str) -> bool:
 def generate_change_password_token() -> str:
     """One-time URL-safe token emailed for the password-reset flow."""
     return secrets.token_urlsafe(32)
+
+
+# ---- Multi-site session state ----
+
+
+def sign_in(site_id: int) -> None:
+    """Mark the current visitor as signed in to `site_id`.
+
+    A single Flask cookie holds the list of all sites the visitor is
+    currently signed in to — so going from site A to site B doesn't sign
+    you out of A.
+    """
+    signed_in = _signed_in_sites()
+    if site_id not in signed_in:
+        session[_SESSION_KEY] = [*signed_in, site_id]
+
+
+def sign_out(site_id: int) -> None:
+    signed_in = _signed_in_sites()
+    if site_id in signed_in:
+        session[_SESSION_KEY] = [s for s in signed_in if s != site_id]
+
+
+def is_signed_in_to(site_id: int) -> bool:
+    return site_id in _signed_in_sites()
+
+
+def _signed_in_sites() -> list[int]:
+    return list(session.get(_SESSION_KEY, []))
+
+
+# ---- Permission matrix ----
+
+
+def is_action_allowed(*, site: Any, action: str) -> bool:
+    """Return True if the current visitor can perform `action` on `site`.
+
+    Actions: "view" (read latest revision), "view_revision" (read an old
+    revision), "edit" (write a page, including draft endpoints), "admin"
+    (settings/design/delete/export/change-password while signed in).
+
+    Mirrors the matrix from the 2007 auth module:
+    - unclaimed sites are wide open
+    - private sites (the default) require a signed-in user for everything
+    - public sites expose the latest revision but lock down history / edits
+    - open sites expose view + edit but still gate admin behind a login
+    """
+    if site is None:
+        return False
+    if site.password is None:
+        return True
+
+    if is_signed_in_to(site.id):
+        return True
+
+    security = site.security or "private"
+    if security == "open":
+        return action != "admin"
+    if security == "public":
+        return action == "view"
+    return False

--- a/jottit/db.py
+++ b/jottit/db.py
@@ -434,6 +434,72 @@ def new_draft(conn: Connection, *, page_id: int, content: str) -> None:
         conn.execute(update(drafts).where(drafts.c.page_id == page_id).values(content=content))
 
 
+# ---- Site auth + settings ----
+
+
+def claim_site(
+    conn: Connection,
+    *,
+    site_id: int,
+    password_hash: str,
+    email: str,
+    security: str,
+) -> None:
+    """Set the initial password, email, and security level on a fresh site.
+
+    The site is "claimed" the moment `sites.password` is non-null — claim
+    bundles password+email+security because the original UX collected all
+    three on a single form.
+    """
+    conn.execute(
+        update(sites)
+        .where(sites.c.id == site_id)
+        .values(password=password_hash, email=email, security=security)
+    )
+
+
+def set_password(conn: Connection, *, site_id: int, password_hash: str) -> None:
+    conn.execute(update(sites).where(sites.c.id == site_id).values(password=password_hash))
+
+
+def set_change_pwd_token(conn: Connection, *, site_id: int, token: str) -> None:
+    """Store a one-time token used by the password-recovery email link."""
+    conn.execute(update(sites).where(sites.c.id == site_id).values(change_pwd_token=token))
+
+
+def recover_password(conn: Connection, *, site_id: int, password_hash: str) -> None:
+    """Replace the password and atomically clear the recovery token."""
+    conn.execute(
+        update(sites)
+        .where(sites.c.id == site_id)
+        .values(password=password_hash, change_pwd_token=None)
+    )
+
+
+def update_site(
+    conn: Connection,
+    *,
+    site_id: int,
+    title: str | None = None,
+    subtitle: str | None = None,
+    email: str | None = None,
+    security: str | None = None,
+) -> None:
+    """Patch a subset of the site settings fields. Unprovided fields are untouched."""
+    values: dict[str, str | None] = {}
+    if title is not None:
+        values["title"] = title
+    if subtitle is not None:
+        values["subtitle"] = subtitle
+    if email is not None:
+        values["email"] = email
+    if security is not None:
+        values["security"] = security
+    if not values:
+        return
+    conn.execute(update(sites).where(sites.c.id == site_id).values(**values))
+
+
 def new_site(
     conn: Connection,
     *,

--- a/jottit/mail.py
+++ b/jottit/mail.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from flask import current_app
+
+# Log-only mail stub. M8 will swap the body of `send()` for real SMTP and
+# keep the outbox shape (or replace it with the equivalent record-mode the
+# SMTP backend ships).
+
+
+@dataclass
+class SentEmail:
+    to: str
+    subject: str
+    body: str
+
+
+@dataclass
+class Outbox:
+    sent: list[SentEmail] = field(default_factory=list)
+
+
+def outbox() -> Outbox:
+    extensions = current_app.extensions
+    if "outbox" not in extensions:
+        extensions["outbox"] = Outbox()
+    return extensions["outbox"]
+
+
+def send(*, to: str, subject: str, body: str) -> None:
+    """Record an outbound email. Logs a one-liner; full body lives in the outbox."""
+    current_app.logger.info("mail: to=%s subject=%r", to, subject)
+    outbox().sent.append(SentEmail(to=to, subject=subject, body=body))

--- a/jottit/templates/change_password.html
+++ b/jottit/templates/change_password.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Set a new password</title>
+</head>
+<body>
+  <h1>Set a new password</h1>
+  {% if error %}<p class="error">{{ error }}</p>{% endif %}
+  <form method="post">
+    <input type="hidden" name="d" value="{{ token }}">
+    <p>
+      <label>New password<br>
+        <input type="password" name="new_password" required autofocus>
+      </label>
+    </p>
+    <p><button type="submit">Set password</button></p>
+  </form>
+</body>
+</html>

--- a/jottit/templates/claim_site.html
+++ b/jottit/templates/claim_site.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Claim this site</title>
+</head>
+<body>
+  <h1>Claim this site</h1>
+  {% if error %}<p class="error">{{ error }}</p>{% endif %}
+  <form method="post">
+    <p>
+      <label>Password<br>
+        <input type="password" name="password" value="{{ password }}" required>
+      </label>
+    </p>
+    <p>
+      <label>Email<br>
+        <input type="email" name="email" value="{{ email }}" required>
+      </label>
+    </p>
+    <fieldset>
+      <legend>Security</legend>
+      <p><label><input type="radio" name="security" value="private" {% if security == "private" %}checked{% endif %}> Private — only you can view or edit</label></p>
+      <p><label><input type="radio" name="security" value="public" {% if security == "public" %}checked{% endif %}> Public — anyone can view, only you can edit</label></p>
+      <p><label><input type="radio" name="security" value="open" {% if security == "open" %}checked{% endif %}> Open — anyone can view or edit</label></p>
+    </fieldset>
+    <p><button type="submit">Claim site</button></p>
+  </form>
+</body>
+</html>

--- a/jottit/templates/forgot_password.html
+++ b/jottit/templates/forgot_password.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Forgot your password?</title>
+</head>
+<body>
+  <h1>Forgot your password?</h1>
+  {% if sent %}
+    <p>We've emailed a password reset link to the address on file.</p>
+  {% else %}
+    <p>We'll email a one-time password reset link to the email address on file for this site.</p>
+    <form method="post">
+      <p><button type="submit">Email me a reset link</button></p>
+    </form>
+  {% endif %}
+</body>
+</html>

--- a/jottit/templates/signin.html
+++ b/jottit/templates/signin.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Sign in</title>
+</head>
+<body>
+  <h1>Sign in</h1>
+  {% if error %}<p class="error">{{ error }}</p>{% endif %}
+  <form method="post">
+    <input type="hidden" name="return_to" value="{{ return_to }}">
+    <p>
+      <label>Password<br>
+        <input type="password" name="password" required autofocus>
+      </label>
+    </p>
+    <p><button type="submit">Sign in</button></p>
+  </form>
+  <p><a href="site/forgot-password">Forgot your password?</a></p>
+</body>
+</html>

--- a/jottit/views/draft.py
+++ b/jottit/views/draft.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from flask import abort, g, jsonify, request
 from flask.typing import ResponseReturnValue
 
+from jottit import auth
 from jottit.db import (
     delete_draft,
     get_page,
@@ -15,6 +16,8 @@ from jottit.db import (
 
 def save(site_slug: str) -> ResponseReturnValue:
     """Autosave the editor's current textarea content as a draft."""
+    if (response := _gate_edit()) is not None:
+        return response
     page = _resolve_page()
     if page is None:
         return "", 204
@@ -26,6 +29,8 @@ def save(site_slug: str) -> ResponseReturnValue:
 
 def cancel(site_slug: str) -> ResponseReturnValue:
     """Discard the current draft and persist the latest caret/scroll position."""
+    if (response := _gate_edit()) is not None:
+        return response
     page = _resolve_page()
     if page is None:
         return "", 204
@@ -45,6 +50,8 @@ def recover_live_version(site_slug: str) -> ResponseReturnValue:
     server clears the draft, sends back the live content, the textarea
     re-populates from it.
     """
+    if (response := _gate_edit()) is not None:
+        return response
     page = _resolve_page()
     if page is None:
         return jsonify(content="")
@@ -53,6 +60,12 @@ def recover_live_version(site_slug: str) -> ResponseReturnValue:
     revision = get_revision(conn, page_id=page.id)
     delete_draft(conn, page_id=page.id)
     return jsonify(content=revision.content if revision is not None else "")
+
+
+def _gate_edit() -> ResponseReturnValue | None:
+    if g.site is None:
+        abort(404)
+    return auth.gate("edit")
 
 
 def _conn():

--- a/jottit/views/page.py
+++ b/jottit/views/page.py
@@ -4,6 +4,7 @@ from flask import abort, g, jsonify, redirect, render_template, request
 from flask.typing import ResponseReturnValue
 from sqlalchemy import Connection
 
+from jottit import auth
 from jottit.db import (
     delete_page,
     get_draft,
@@ -31,6 +32,9 @@ def view(site_slug: str, page_name: str) -> ResponseReturnValue:
         abort(500)
 
     mode = request.args.get("m", "view")
+    action = _action_for(mode)
+    if (response := auth.gate(action)) is not None:
+        return response
 
     if request.method == "POST":
         if mode == "current_revision":
@@ -41,6 +45,22 @@ def view(site_slug: str, page_name: str) -> ResponseReturnValue:
         return _render_edit_form(conn, page_name)
 
     return _render_view(conn, page_name)
+
+
+def _action_for(mode: str) -> str:
+    """Map a (method, mode) pair onto the auth-matrix action label."""
+    if request.method == "POST":
+        # current_revision is a JSON probe used by the editor JS, so it
+        # logically requires the same permission as the edit it's about
+        # to perform.
+        return "edit"
+    if mode == "edit":
+        return "edit"
+    # GET ?r=N exposes an old revision, which is gated more tightly than
+    # the latest one on `public` sites — see is_action_allowed.
+    if request.args.get("r") is not None:
+        return "view_revision"
+    return "view"
 
 
 def _render_view(conn: Connection, page_name: str) -> ResponseReturnValue:

--- a/jottit/views/site.py
+++ b/jottit/views/site.py
@@ -1,10 +1,82 @@
 from __future__ import annotations
 
-from flask import request
+from flask import abort, g, redirect, render_template, request
+from flask.typing import ResponseReturnValue
+
+from jottit import auth, mail
+from jottit.db import claim_site, get_request_conn
+from jottit.urls import site_root
+
+_ALLOWED_SECURITY_LEVELS = {"private", "public", "open"}
 
 
-def claim(site_slug: str) -> str:
-    return f"site:{site_slug} site/claim {request.method} (TODO)"
+def claim(site_slug: str) -> ResponseReturnValue:
+    if g.site is None:
+        abort(404)
+    if g.site.password is not None:
+        # Already claimed — claim is one-shot, send the visitor home.
+        return redirect(site_root(), code=303)
+
+    if request.method == "GET":
+        return render_template(
+            "claim_site.html",
+            password="",
+            email="",
+            security="private",
+            error=None,
+        )
+
+    password = request.form.get("password", "")
+    email = request.form.get("email", "")
+    security = request.form.get("security", "private")
+
+    error = _validate_claim(password=password, email=email, security=security)
+    if error is not None:
+        return render_template(
+            "claim_site.html",
+            password=password,
+            email=email,
+            security=security,
+            error=error,
+        ), 400
+
+    conn = get_request_conn()
+    if conn is None:
+        abort(500)
+
+    claim_site(
+        conn,
+        site_id=g.site.id,
+        password_hash=auth.hash_password(password),
+        email=email,
+        security=security,
+    )
+    auth.sign_in(g.site.id)
+    _send_welcome_email(to=email)
+    return redirect(site_root(), code=303)
+
+
+def _validate_claim(*, password: str, email: str, security: str) -> str | None:
+    if not password:
+        return "Please choose a password."
+    if not email or "@" not in email:
+        return "Please enter a valid email address."
+    if security not in _ALLOWED_SECURITY_LEVELS:
+        return "Pick a valid security level."
+    return None
+
+
+def _send_welcome_email(*, to: str) -> None:
+    mail.send(
+        to=to,
+        subject="You claimed your Jottit site",
+        body=(
+            "Thanks for claiming your site at Jottit. You can sign back in "
+            "any time at https://"
+            f"{request.host}{site_root()}site/signin — and recover your "
+            f"password at https://{request.host}{site_root()}site/forgot-password.\n"
+        ),
+    )
 
 
 def signin(site_slug: str) -> str:

--- a/jottit/views/site.py
+++ b/jottit/views/site.py
@@ -6,7 +6,7 @@ from flask import abort, g, redirect, render_template, request
 from flask.typing import ResponseReturnValue
 
 from jottit import auth, mail
-from jottit.db import claim_site, get_request_conn
+from jottit.db import claim_site, get_request_conn, recover_password, set_change_pwd_token
 from jottit.urls import site_root
 
 _ALLOWED_SECURITY_LEVELS = {"private", "public", "open"}
@@ -135,12 +135,73 @@ def _safe_return_to(value: str) -> str:
     return value.lstrip("/")
 
 
-def forgot_password(site_slug: str) -> str:
-    return f"site:{site_slug} site/forgot-password {request.method} (TODO)"
+def forgot_password(site_slug: str) -> ResponseReturnValue:
+    if g.site is None:
+        abort(404)
+    if g.site.password is None:
+        # Nothing to recover on an unclaimed site.
+        return redirect(site_root(), code=303)
+
+    if request.method == "GET":
+        return render_template("forgot_password.html", sent=False)
+
+    conn = get_request_conn()
+    if conn is None:
+        abort(500)
+
+    token = auth.generate_change_password_token()
+    set_change_pwd_token(conn, site_id=g.site.id, token=token)
+    _send_recovery_email(to=g.site.email, token=token)
+    return render_template("forgot_password.html", sent=True)
 
 
-def change_password(site_slug: str) -> str:
-    return f"site:{site_slug} site/change-password {request.method} (TODO)"
+def change_password(site_slug: str) -> ResponseReturnValue:
+    if g.site is None:
+        abort(404)
+    if g.site.password is None:
+        return redirect(site_root(), code=303)
+
+    token = request.values.get("d", "")
+    stored = g.site.change_pwd_token
+    # Both `not stored` and `token != stored` collapse to "no valid token".
+    # Treat them identically to avoid leaking which one failed.
+    if not stored or token != stored:
+        return redirect(site_root(), code=303)
+
+    if request.method == "GET":
+        return render_template("change_password.html", token=token, error=None)
+
+    new_password = request.form.get("new_password", "")
+    if not new_password:
+        return render_template(
+            "change_password.html",
+            token=token,
+            error="Please enter a new password.",
+        ), 400
+
+    conn = get_request_conn()
+    if conn is None:
+        abort(500)
+
+    recover_password(conn, site_id=g.site.id, password_hash=auth.hash_password(new_password))
+    auth.sign_in(g.site.id)
+    return redirect(site_root(), code=303)
+
+
+def _send_recovery_email(*, to: str, token: str) -> None:
+    change_url = f"https://{request.host}{site_root()}site/change-password?d={token}"
+    forgot_url = f"https://{request.host}{site_root()}site/forgot-password"
+    mail.send(
+        to=to,
+        subject="Password reset for your Jottit site",
+        body=(
+            "Someone asked to reset the password on your Jottit site. If it "
+            "wasn't you, you can ignore this email.\n\n"
+            f"To set a new password, visit:\n{change_url}\n\n"
+            "This link works once. If you need another, visit:\n"
+            f"{forgot_url}\n"
+        ),
+    )
 
 
 def changes(site_slug: str) -> str:

--- a/jottit/views/site.py
+++ b/jottit/views/site.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 from flask import abort, g, redirect, render_template, request
 from flask.typing import ResponseReturnValue
 
@@ -79,12 +81,58 @@ def _send_welcome_email(*, to: str) -> None:
     )
 
 
-def signin(site_slug: str) -> str:
-    return f"site:{site_slug} site/signin {request.method} (TODO)"
+def signin(site_slug: str) -> ResponseReturnValue:
+    if g.site is None:
+        abort(404)
+    # An unclaimed site has no password to compare against — sign-in is a no-op
+    # there; send them home so they can claim instead.
+    if g.site.password is None:
+        return redirect(site_root(), code=303)
+
+    return_to = _safe_return_to(request.values.get("return_to", ""))
+
+    if request.method == "GET":
+        return render_template(
+            "signin.html",
+            return_to=return_to,
+            error=None,
+        )
+
+    password = request.form.get("password", "")
+    if not auth.verify_password(password, g.site.password):
+        return render_template(
+            "signin.html",
+            return_to=return_to,
+            error="That password doesn't match.",
+        ), 401
+
+    auth.sign_in(g.site.id)
+    return redirect(site_root() + return_to.lstrip("/"), code=303)
 
 
-def signout(site_slug: str) -> str:
-    return f"site:{site_slug} site/signout POST (TODO)"
+def signout(site_slug: str) -> ResponseReturnValue:
+    if g.site is not None:
+        auth.sign_out(g.site.id)
+    return_to = _safe_return_to(request.form.get("return_to", ""))
+    return redirect(site_root() + return_to.lstrip("/"), code=303)
+
+
+def _safe_return_to(value: str) -> str:
+    """Strip any scheme/host off a `return_to` parameter to block open redirects.
+
+    Only same-site relative paths survive — `//evil.com/` becomes `""`, and
+    so does `https://evil.com/`. The leading `/` is also stripped so the
+    caller can concatenate with `site_root()` without doubling it up.
+    """
+    if not value:
+        return ""
+    parsed = urlparse(value)
+    if parsed.scheme or parsed.netloc:
+        return ""
+    # `//foo` parses as netloc-only on some Python versions; belt-and-braces.
+    if value.startswith("//"):
+        return ""
+    return value.lstrip("/")
 
 
 def forgot_password(site_slug: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "sqlalchemy>=2.0",
     "alembic>=1.13",
     "psycopg[binary]>=3.1",
+    "argon2-cffi>=23.1",
     "mistune>=3.0",
     "nh3>=0.2",
     "markupsafe>=2.1",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,25 @@
 from __future__ import annotations
 
-from jottit.auth import generate_change_password_token, hash_password, verify_password
+from dataclasses import dataclass
+
+from flask import Flask
+
+from jottit.auth import (
+    generate_change_password_token,
+    hash_password,
+    is_action_allowed,
+    is_signed_in_to,
+    sign_in,
+    sign_out,
+    verify_password,
+)
+
+
+@dataclass
+class _FakeSite:
+    id: int
+    password: str | None = None
+    security: str = "private"
 
 
 def test_hash_password_returns_argon2_string() -> None:
@@ -33,3 +52,105 @@ def test_generate_change_password_token_is_long_and_unique() -> None:
     # token_urlsafe(32) is 43 chars; bound loosely for libstdlib versioning.
     assert len(a) >= 40
     assert a != b
+
+
+# ---- session helpers ----
+
+
+def test_sign_in_adds_site_to_session(app: Flask) -> None:
+    with app.test_request_context("/"):
+        assert is_signed_in_to(42) is False
+        sign_in(42)
+        assert is_signed_in_to(42) is True
+
+
+def test_sign_in_is_idempotent(app: Flask) -> None:
+    from flask import session
+
+    with app.test_request_context("/"):
+        sign_in(42)
+        sign_in(42)
+        assert session["signed_in_sites"] == [42]
+
+
+def test_sign_in_supports_multiple_sites(app: Flask) -> None:
+    with app.test_request_context("/"):
+        sign_in(1)
+        sign_in(2)
+        assert is_signed_in_to(1)
+        assert is_signed_in_to(2)
+
+
+def test_sign_out_removes_one_site_only(app: Flask) -> None:
+    with app.test_request_context("/"):
+        sign_in(1)
+        sign_in(2)
+        sign_out(1)
+        assert is_signed_in_to(1) is False
+        assert is_signed_in_to(2) is True
+
+
+def test_sign_out_unknown_site_is_noop(app: Flask) -> None:
+    with app.test_request_context("/"):
+        sign_out(99)  # should not raise
+        assert is_signed_in_to(99) is False
+
+
+# ---- permission matrix ----
+
+
+def test_no_site_denies_everything(app: Flask) -> None:
+    with app.test_request_context("/"):
+        assert is_action_allowed(site=None, action="view") is False
+        assert is_action_allowed(site=None, action="edit") is False
+
+
+def test_unclaimed_site_allows_everything(app: Flask) -> None:
+    site = _FakeSite(id=1, password=None, security="private")
+    with app.test_request_context("/"):
+        assert is_action_allowed(site=site, action="view") is True
+        assert is_action_allowed(site=site, action="edit") is True
+        assert is_action_allowed(site=site, action="admin") is True
+
+
+def test_signed_in_user_can_do_anything(app: Flask) -> None:
+    site = _FakeSite(id=1, password="$argon2id$x", security="private")
+    with app.test_request_context("/"):
+        sign_in(1)
+        assert is_action_allowed(site=site, action="view") is True
+        assert is_action_allowed(site=site, action="edit") is True
+        assert is_action_allowed(site=site, action="admin") is True
+
+
+def test_private_site_denies_signed_out_visitors(app: Flask) -> None:
+    site = _FakeSite(id=1, password="$argon2id$x", security="private")
+    with app.test_request_context("/"):
+        assert is_action_allowed(site=site, action="view") is False
+        assert is_action_allowed(site=site, action="edit") is False
+        assert is_action_allowed(site=site, action="admin") is False
+
+
+def test_public_site_allows_view_but_blocks_edit_and_admin(app: Flask) -> None:
+    site = _FakeSite(id=1, password="$argon2id$x", security="public")
+    with app.test_request_context("/"):
+        assert is_action_allowed(site=site, action="view") is True
+        assert is_action_allowed(site=site, action="view_revision") is False
+        assert is_action_allowed(site=site, action="edit") is False
+        assert is_action_allowed(site=site, action="admin") is False
+
+
+def test_open_site_allows_view_and_edit_but_blocks_admin(app: Flask) -> None:
+    site = _FakeSite(id=1, password="$argon2id$x", security="open")
+    with app.test_request_context("/"):
+        assert is_action_allowed(site=site, action="view") is True
+        assert is_action_allowed(site=site, action="edit") is True
+        assert is_action_allowed(site=site, action="admin") is False
+
+
+def test_session_is_scoped_per_site(app: Flask) -> None:
+    site_a = _FakeSite(id=1, password="$argon2id$x", security="private")
+    site_b = _FakeSite(id=2, password="$argon2id$x", security="private")
+    with app.test_request_context("/"):
+        sign_in(1)
+        assert is_action_allowed(site=site_a, action="admin") is True
+        assert is_action_allowed(site=site_b, action="admin") is False

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from jottit.auth import generate_change_password_token, hash_password, verify_password
+
+
+def test_hash_password_returns_argon2_string() -> None:
+    out = hash_password("hunter2")
+    assert out.startswith("$argon2")
+    assert "hunter2" not in out
+
+
+def test_hash_password_is_salted_so_repeats_differ() -> None:
+    assert hash_password("hunter2") != hash_password("hunter2")
+
+
+def test_verify_password_accepts_correct_password() -> None:
+    h = hash_password("hunter2")
+    assert verify_password("hunter2", h) is True
+
+
+def test_verify_password_rejects_wrong_password() -> None:
+    h = hash_password("hunter2")
+    assert verify_password("nope", h) is False
+
+
+def test_verify_password_rejects_malformed_hash() -> None:
+    assert verify_password("hunter2", "not-an-argon2-hash") is False
+
+
+def test_generate_change_password_token_is_long_and_unique() -> None:
+    a = generate_change_password_token()
+    b = generate_change_password_token()
+    # token_urlsafe(32) is 43 chars; bound loosely for libstdlib versioning.
+    assert len(a) >= 40
+    assert a != b

--- a/tests/test_auth_gating.py
+++ b/tests/test_auth_gating.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from flask.testing import FlaskClient
+from sqlalchemy import Engine
+
+from jottit.auth import hash_password
+from jottit.db import (
+    claim_site,
+    drafts,
+    get_draft,
+    get_page,
+    metadata,
+    new_page,
+    new_site,
+)
+
+APEX = "http://jottit.test/"
+
+
+@pytest.fixture(autouse=True)
+def _truncate(db_engine: Engine) -> Iterator[None]:
+    yield
+    with db_engine.begin() as conn:
+        for table in reversed(metadata.sorted_tables):
+            conn.execute(table.delete())
+
+
+def _seed_site(
+    db_engine: Engine,
+    *,
+    secret_url: str,
+    public_url: str | None = None,
+    security: str | None = None,
+    password: str | None = "hunter2",
+) -> int:
+    """Seed a site. When `password` is None the site is unclaimed.
+
+    `security` is meaningless on an unclaimed site (the auth matrix
+    short-circuits on `password is None`), so it's only stored when a
+    password is set.
+    """
+    with db_engine.begin() as conn:
+        site_id = new_site(conn, content="hi", secret_url=secret_url, public_url=public_url)
+        if password is not None:
+            claim_site(
+                conn,
+                site_id=site_id,
+                password_hash=hash_password(password),
+                email="owner@example.com",
+                security=security or "private",
+            )
+    return site_id
+
+
+def _sign_in(client: FlaskClient, *, base_url: str, site_id: int) -> None:
+    with client.session_transaction(base_url=base_url) as sess:
+        sess["signed_in_sites"] = [*sess.get("signed_in_sites", []), site_id]
+
+
+# ---- Private sites lock everything down ----
+
+
+def test_private_site_get_view_redirects_anonymous_to_signin(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="pr1", public_url="alpha", security="private")
+
+    response = client.get("/", base_url="http://alpha.jottit.test/")
+
+    assert response.status_code == 303
+    location = response.headers["Location"]
+    assert urlparse(location).path == "/site/signin"
+
+
+def test_private_site_get_view_with_session_renders_page(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_site(db_engine, secret_url="pr2", public_url="beta", security="private")
+    _sign_in(client, base_url="http://beta.jottit.test/", site_id=site_id)
+
+    response = client.get("/", base_url="http://beta.jottit.test/")
+
+    assert response.status_code == 200
+
+
+def test_private_site_post_save_returns_401_when_anonymous(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="pr3", public_url="gamma", security="private")
+
+    response = client.post("/", base_url="http://gamma.jottit.test/", data={"content": "x"})
+
+    assert response.status_code == 401
+
+
+# ---- Public sites allow read, gate everything else ----
+
+
+def test_public_site_anonymous_can_view_latest_revision(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="pu1", public_url="delta", security="public")
+
+    response = client.get("/", base_url="http://delta.jottit.test/")
+
+    assert response.status_code == 200
+
+
+def test_public_site_anonymous_revision_view_redirects_to_signin(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="pu2", public_url="epsilon", security="public")
+
+    response = client.get("/?r=1", base_url="http://epsilon.jottit.test/")
+
+    assert response.status_code == 303
+    assert urlparse(response.headers["Location"]).path == "/site/signin"
+
+
+def test_public_site_anonymous_edit_form_redirects_to_signin(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="pu3", public_url="zeta", security="public")
+
+    response = client.get("/?m=edit", base_url="http://zeta.jottit.test/")
+
+    assert response.status_code == 303
+    assert urlparse(response.headers["Location"]).path == "/site/signin"
+
+
+def test_public_site_anonymous_save_returns_401(client: FlaskClient, db_engine: Engine) -> None:
+    _seed_site(db_engine, secret_url="pu4", public_url="eta", security="public")
+
+    response = client.post("/", base_url="http://eta.jottit.test/", data={"content": "x"})
+
+    assert response.status_code == 401
+
+
+def test_public_site_signed_in_user_can_edit(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="pu5", public_url="theta", security="public")
+    _sign_in(client, base_url="http://theta.jottit.test/", site_id=site_id)
+
+    response = client.post("/", base_url="http://theta.jottit.test/", data={"content": "edited"})
+
+    assert response.status_code == 303
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+
+
+# ---- Open sites allow everything except admin ----
+
+
+def test_open_site_anonymous_can_save(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="op1", public_url="iota", security="open")
+
+    response = client.post(
+        "/notes", base_url="http://iota.jottit.test/", data={"content": "wiki-style"}
+    )
+
+    assert response.status_code == 303
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="notes")
+        assert page is not None
+
+
+# ---- Draft endpoints ----
+
+
+def test_private_site_draft_save_returns_401_anonymously(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_site(db_engine, secret_url="dr1", public_url="kappa", security="private")
+    with db_engine.begin() as conn:
+        new_page(conn, site_id=site_id, name="notes", content="x")
+
+    response = client.post(
+        "/draft/save",
+        base_url="http://kappa.jottit.test/",
+        data={"page_name": "notes", "content": "draft"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_public_site_draft_save_returns_401_anonymously(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="dr2", public_url="lambda", security="public")
+
+    response = client.post(
+        "/draft/save",
+        base_url="http://lambda.jottit.test/",
+        data={"page_name": "", "content": "x"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_public_site_draft_save_succeeds_when_signed_in(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_site(db_engine, secret_url="dr3", public_url="mu", security="public")
+    _sign_in(client, base_url="http://mu.jottit.test/", site_id=site_id)
+
+    response = client.post(
+        "/draft/save",
+        base_url="http://mu.jottit.test/",
+        data={"page_name": "", "content": "draft body"},
+    )
+
+    assert response.status_code == 204
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        assert get_draft(conn, page_id=page.id) is not None
+
+
+def test_open_site_draft_save_allowed_anonymously(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="dr4", public_url="nu", security="open")
+
+    response = client.post(
+        "/draft/save",
+        base_url="http://nu.jottit.test/",
+        data={"page_name": "", "content": "anon draft"},
+    )
+
+    assert response.status_code == 204
+    with db_engine.connect() as conn:
+        page = get_page(conn, site_id=site_id, page_name="")
+        assert page is not None
+        rows = conn.execute(drafts.select().where(drafts.c.page_id == page.id)).all()
+        assert len(rows) == 1
+
+
+# ---- return_to wiring ----
+
+
+def test_signin_redirect_carries_return_to_for_subdomain(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="rt1", public_url="xi", security="private")
+
+    response = client.get("/notes?m=edit", base_url="http://xi.jottit.test/")
+
+    assert response.status_code == 303
+    qs = parse_qs(urlparse(response.headers["Location"]).query)
+    assert qs["return_to"] == ["notes?m=edit"]
+
+
+def test_signin_redirect_carries_return_to_for_secret_url(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_site(db_engine, secret_url="abc12", security="private")
+
+    response = client.get("/abc12/notes?m=edit", base_url=APEX)
+
+    assert response.status_code == 303
+    parsed = urlparse(response.headers["Location"])
+    assert parsed.path == "/abc12/site/signin"
+    assert parse_qs(parsed.query)["return_to"] == ["notes?m=edit"]
+
+
+def test_end_to_end_signin_returns_to_original_url(client: FlaskClient, db_engine: Engine) -> None:
+    """Full loop: hit a gated URL → follow the redirect to signin → submit → end up where we started."""
+    _seed_site(db_engine, secret_url="e2e", public_url="omicron", security="private")
+
+    initial = client.get("/notes?m=edit", base_url="http://omicron.jottit.test/")
+    signin_url = initial.headers["Location"]
+    return_to = parse_qs(urlparse(signin_url).query)["return_to"][0]
+
+    final = client.post(
+        urlparse(signin_url).path,
+        base_url="http://omicron.jottit.test/",
+        data={"password": "hunter2", "return_to": return_to},
+    )
+
+    assert final.status_code == 303
+    # The signin handler concatenates site_root + lstripped return_to, so
+    # we should land back at /notes?m=edit (modulo encoding).
+    assert final.headers["Location"] == "/notes?m=edit"
+
+
+# ---- Unclaimed sites stay open ----
+
+
+def test_unclaimed_site_does_not_require_signin(client: FlaskClient, db_engine: Engine) -> None:
+    _seed_site(db_engine, secret_url="un1", public_url="pi", password=None)
+
+    response = client.post("/", base_url="http://pi.jottit.test/", data={"content": "fresh"})
+
+    assert response.status_code == 303

--- a/tests/test_claim.py
+++ b/tests/test_claim.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+from sqlalchemy import Engine
+
+from jottit.auth import verify_password
+from jottit.db import get_site, metadata, new_site
+from jottit.mail import Outbox
+
+APEX = "http://jottit.test/"
+
+
+@pytest.fixture(autouse=True)
+def _truncate_and_reset_outbox(db_engine: Engine, app: Flask) -> Iterator[None]:
+    yield
+    with db_engine.begin() as conn:
+        for table in reversed(metadata.sorted_tables):
+            conn.execute(table.delete())
+    # Reset the outbox so leaked sends from one test don't bleed into the next.
+    app.extensions.pop("outbox", None)
+
+
+def _seed_site(db_engine: Engine, *, secret_url: str, public_url: str | None = None) -> int:
+    with db_engine.begin() as conn:
+        return new_site(conn, content="seed", secret_url=secret_url, public_url=public_url)
+
+
+# ---- GET ----
+
+
+def test_get_claim_renders_form_when_unclaimed(client: FlaskClient, db_engine: Engine) -> None:
+    _seed_site(db_engine, secret_url="cl1", public_url="alpha")
+
+    response = client.get("/site/claim", base_url="http://alpha.jottit.test/")
+
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert 'name="password"' in body
+    assert 'name="email"' in body
+    assert 'name="security"' in body
+
+
+def test_get_claim_redirects_when_already_claimed(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="cl2", public_url="beta")
+    with db_engine.begin() as conn:
+        from jottit.db import claim_site as db_claim_site
+
+        db_claim_site(
+            conn,
+            site_id=site_id,
+            password_hash="$argon2id$existing",
+            email="owner@example.com",
+            security="private",
+        )
+
+    response = client.get("/site/claim", base_url="http://beta.jottit.test/")
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/"
+
+
+# ---- POST ----
+
+
+def test_post_claim_hashes_password_and_stores_site_fields(
+    client: FlaskClient, db_engine: Engine, app: Flask
+) -> None:
+    site_id = _seed_site(db_engine, secret_url="cl3", public_url="gamma")
+
+    response = client.post(
+        "/site/claim",
+        base_url="http://gamma.jottit.test/",
+        data={"password": "hunter2", "email": "owner@example.com", "security": "public"},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/"
+
+    with db_engine.connect() as conn:
+        site = get_site(conn, site_id=site_id)
+        assert site is not None
+        assert site.password is not None
+        assert site.password.startswith("$argon2")
+        assert verify_password("hunter2", site.password)
+        assert site.email == "owner@example.com"
+        assert site.security == "public"
+
+
+def test_post_claim_signs_user_in(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="cl4", public_url="delta")
+
+    client.post(
+        "/site/claim",
+        base_url="http://delta.jottit.test/",
+        data={"password": "hunter2", "email": "o@example.com", "security": "private"},
+    )
+
+    with client.session_transaction(base_url="http://delta.jottit.test/") as sess:
+        assert site_id in sess["signed_in_sites"]
+
+
+def test_post_claim_sends_welcome_email(client: FlaskClient, db_engine: Engine, app: Flask) -> None:
+    _seed_site(db_engine, secret_url="cl5", public_url="epsilon")
+
+    client.post(
+        "/site/claim",
+        base_url="http://epsilon.jottit.test/",
+        data={"password": "hunter2", "email": "owner@example.com", "security": "private"},
+    )
+
+    outbox: Outbox = app.extensions["outbox"]
+    assert len(outbox.sent) == 1
+    msg = outbox.sent[0]
+    assert msg.to == "owner@example.com"
+    assert "claimed" in msg.subject.lower()
+
+
+def test_post_claim_rejects_missing_password(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="cl6", public_url="zeta")
+
+    response = client.post(
+        "/site/claim",
+        base_url="http://zeta.jottit.test/",
+        data={"password": "", "email": "o@example.com", "security": "private"},
+    )
+
+    assert response.status_code == 400
+    with db_engine.connect() as conn:
+        site = get_site(conn, site_id=site_id)
+        assert site is not None
+        assert site.password is None
+
+
+def test_post_claim_rejects_invalid_email(client: FlaskClient, db_engine: Engine) -> None:
+    _seed_site(db_engine, secret_url="cl7", public_url="eta")
+
+    response = client.post(
+        "/site/claim",
+        base_url="http://eta.jottit.test/",
+        data={"password": "x", "email": "not-an-email", "security": "private"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_post_claim_rejects_invalid_security_level(client: FlaskClient, db_engine: Engine) -> None:
+    _seed_site(db_engine, secret_url="cl8", public_url="theta")
+
+    response = client.post(
+        "/site/claim",
+        base_url="http://theta.jottit.test/",
+        data={"password": "x", "email": "o@example.com", "security": "superadmin"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_post_claim_when_already_claimed_redirects(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_site(db_engine, secret_url="cl9", public_url="iota")
+    with db_engine.begin() as conn:
+        from jottit.db import claim_site as db_claim_site
+
+        db_claim_site(
+            conn,
+            site_id=site_id,
+            password_hash="$argon2id$existing",
+            email="orig@example.com",
+            security="private",
+        )
+
+    response = client.post(
+        "/site/claim",
+        base_url="http://iota.jottit.test/",
+        data={"password": "new-pw", "email": "new@example.com", "security": "open"},
+    )
+
+    assert response.status_code == 303
+    # And the existing password/email are untouched.
+    with db_engine.connect() as conn:
+        site = get_site(conn, site_id=site_id)
+        assert site is not None
+        assert site.email == "orig@example.com"
+        assert site.password == "$argon2id$existing"
+
+
+# ---- secret URL routing ----
+
+
+def test_claim_via_secret_url(client: FlaskClient, db_engine: Engine, app: Flask) -> None:
+    site_id = _seed_site(db_engine, secret_url="abc12")
+
+    response = client.post(
+        "/abc12/site/claim",
+        base_url=APEX,
+        data={"password": "hunter2", "email": "o@example.com", "security": "private"},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/abc12/"
+
+    with db_engine.connect() as conn:
+        site = get_site(conn, site_id=site_id)
+        assert site is not None
+        assert site.password is not None

--- a/tests/test_db_queries.py
+++ b/tests/test_db_queries.py
@@ -5,6 +5,7 @@ from sqlalchemy import Connection, select
 
 from jottit.db import (
     _AMBIGUOUS_CHARS,
+    claim_site,
     delete_draft,
     delete_page,
     designs,
@@ -15,10 +16,14 @@ from jottit.db import (
     new_page,
     new_site,
     pages,
+    recover_password,
     revisions,
+    set_change_pwd_token,
+    set_password,
     undelete_page,
     update_caret_pos,
     update_page,
+    update_site,
 )
 
 
@@ -349,3 +354,121 @@ def test_delete_draft_noop_when_absent(db_conn: Connection) -> None:
     assert page is not None
 
     delete_draft(db_conn, page_id=page.id)  # should not raise
+
+
+# ---- claim_site ----
+
+
+def test_claim_site_sets_password_email_and_security(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="cl1")
+
+    claim_site(
+        db_conn,
+        site_id=site_id,
+        password_hash="$argon2id$fake-hash",
+        email="owner@example.com",
+        security="private",
+    )
+
+    row = get_site(db_conn, site_id=site_id)
+    assert row is not None
+    assert row.password == "$argon2id$fake-hash"
+    assert row.email == "owner@example.com"
+    assert row.security == "private"
+
+
+# ---- set_password ----
+
+
+def test_set_password_only_touches_password_column(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="sp1")
+    claim_site(
+        db_conn,
+        site_id=site_id,
+        password_hash="$argon2id$old",
+        email="owner@example.com",
+        security="public",
+    )
+
+    set_password(db_conn, site_id=site_id, password_hash="$argon2id$new")
+
+    row = get_site(db_conn, site_id=site_id)
+    assert row is not None
+    assert row.password == "$argon2id$new"
+    assert row.email == "owner@example.com"
+    assert row.security == "public"
+
+
+# ---- change_pwd_token / recover_password ----
+
+
+def test_set_change_pwd_token_stores_token(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="tk1")
+
+    set_change_pwd_token(db_conn, site_id=site_id, token="abc123token")
+
+    row = get_site(db_conn, site_id=site_id)
+    assert row is not None
+    assert row.change_pwd_token == "abc123token"
+
+
+def test_recover_password_sets_password_and_clears_token(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="rp1")
+    set_change_pwd_token(db_conn, site_id=site_id, token="one-time-token")
+
+    recover_password(db_conn, site_id=site_id, password_hash="$argon2id$recovered")
+
+    row = get_site(db_conn, site_id=site_id)
+    assert row is not None
+    assert row.password == "$argon2id$recovered"
+    assert row.change_pwd_token is None
+
+
+# ---- update_site ----
+
+
+def test_update_site_patches_only_provided_fields(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="us1")
+    claim_site(
+        db_conn,
+        site_id=site_id,
+        password_hash="$argon2id$x",
+        email="orig@example.com",
+        security="public",
+    )
+
+    update_site(db_conn, site_id=site_id, title="My Site", subtitle="of jottings")
+
+    row = get_site(db_conn, site_id=site_id)
+    assert row is not None
+    assert row.title == "My Site"
+    assert row.subtitle == "of jottings"
+    # Untouched fields are preserved.
+    assert row.email == "orig@example.com"
+    assert row.security == "public"
+
+
+def test_update_site_no_args_is_noop(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="us2")
+
+    update_site(db_conn, site_id=site_id)  # should not raise
+
+    row = get_site(db_conn, site_id=site_id)
+    assert row is not None
+
+
+def test_update_site_can_change_security_level(db_conn: Connection) -> None:
+    site_id = new_site(db_conn, content="hi", secret_url="us3")
+    claim_site(
+        db_conn,
+        site_id=site_id,
+        password_hash="$argon2id$x",
+        email="o@example.com",
+        security="private",
+    )
+
+    update_site(db_conn, site_id=site_id, security="open")
+
+    row = get_site(db_conn, site_id=site_id)
+    assert row is not None
+    assert row.security == "open"

--- a/tests/test_password_recovery.py
+++ b/tests/test_password_recovery.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+from sqlalchemy import Engine
+
+from jottit.auth import hash_password, verify_password
+from jottit.db import claim_site, get_site, metadata, new_site, set_change_pwd_token
+from jottit.mail import Outbox
+
+APEX = "http://jottit.test/"
+
+
+@pytest.fixture(autouse=True)
+def _truncate_and_reset_outbox(db_engine: Engine, app: Flask) -> Iterator[None]:
+    yield
+    with db_engine.begin() as conn:
+        for table in reversed(metadata.sorted_tables):
+            conn.execute(table.delete())
+    app.extensions.pop("outbox", None)
+
+
+def _seed_claimed_site(
+    db_engine: Engine,
+    *,
+    secret_url: str,
+    public_url: str | None = None,
+    password: str = "hunter2",
+    email: str = "owner@example.com",
+) -> int:
+    with db_engine.begin() as conn:
+        site_id = new_site(conn, content="hi", secret_url=secret_url, public_url=public_url)
+        claim_site(
+            conn,
+            site_id=site_id,
+            password_hash=hash_password(password),
+            email=email,
+            security="private",
+        )
+    return site_id
+
+
+# ---- GET /site/forgot-password ----
+
+
+def test_get_forgot_password_renders_form(client: FlaskClient, db_engine: Engine) -> None:
+    _seed_claimed_site(db_engine, secret_url="fp1", public_url="alpha")
+
+    response = client.get("/site/forgot-password", base_url="http://alpha.jottit.test/")
+
+    assert response.status_code == 200
+    assert "Email me a reset link" in response.data.decode()
+
+
+def test_get_forgot_password_redirects_when_unclaimed(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    with db_engine.begin() as conn:
+        new_site(conn, content="hi", secret_url="fp2", public_url="beta")
+
+    response = client.get("/site/forgot-password", base_url="http://beta.jottit.test/")
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/"
+
+
+# ---- POST /site/forgot-password ----
+
+
+def test_post_forgot_password_stores_token_and_sends_email(
+    client: FlaskClient, db_engine: Engine, app: Flask
+) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="fp3", public_url="gamma")
+
+    response = client.post("/site/forgot-password", base_url="http://gamma.jottit.test/")
+
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert "emailed" in body.lower()
+
+    with db_engine.connect() as conn:
+        site = get_site(conn, site_id=site_id)
+        assert site is not None
+        assert site.change_pwd_token is not None
+        assert len(site.change_pwd_token) >= 40
+
+    outbox: Outbox = app.extensions["outbox"]
+    assert len(outbox.sent) == 1
+    msg = outbox.sent[0]
+    assert msg.to == "owner@example.com"
+    assert site.change_pwd_token in msg.body
+    assert "site/change-password" in msg.body
+
+
+def test_post_forgot_password_rotates_token_on_each_request(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="fp4", public_url="delta")
+
+    client.post("/site/forgot-password", base_url="http://delta.jottit.test/")
+    with db_engine.connect() as conn:
+        first = get_site(conn, site_id=site_id)
+    assert first is not None
+    first_token = first.change_pwd_token
+
+    client.post("/site/forgot-password", base_url="http://delta.jottit.test/")
+    with db_engine.connect() as conn:
+        second = get_site(conn, site_id=site_id)
+    assert second is not None
+
+    assert first_token != second.change_pwd_token
+
+
+# ---- GET /site/change-password ----
+
+
+def test_get_change_password_with_valid_token_renders_form(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="cp1", public_url="epsilon")
+    with db_engine.begin() as conn:
+        set_change_pwd_token(conn, site_id=site_id, token="valid-token")
+
+    response = client.get(
+        "/site/change-password?d=valid-token", base_url="http://epsilon.jottit.test/"
+    )
+
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert 'name="new_password"' in body
+    assert 'value="valid-token"' in body
+
+
+def test_get_change_password_with_wrong_token_redirects_home(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="cp2", public_url="zeta")
+    with db_engine.begin() as conn:
+        set_change_pwd_token(conn, site_id=site_id, token="real-token")
+
+    response = client.get("/site/change-password?d=fake-token", base_url="http://zeta.jottit.test/")
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/"
+
+
+def test_get_change_password_with_no_token_stored_redirects_home(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_claimed_site(db_engine, secret_url="cp3", public_url="eta")
+
+    response = client.get("/site/change-password?d=anything", base_url="http://eta.jottit.test/")
+
+    assert response.status_code == 303
+
+
+# ---- POST /site/change-password ----
+
+
+def test_post_change_password_sets_password_clears_token_signs_in(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="cp4", public_url="theta")
+    with db_engine.begin() as conn:
+        set_change_pwd_token(conn, site_id=site_id, token="one-shot")
+
+    response = client.post(
+        "/site/change-password",
+        base_url="http://theta.jottit.test/",
+        data={"d": "one-shot", "new_password": "new-strong-pw"},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/"
+
+    with db_engine.connect() as conn:
+        site = get_site(conn, site_id=site_id)
+        assert site is not None
+        assert site.change_pwd_token is None
+        assert verify_password("new-strong-pw", site.password)
+
+    with client.session_transaction(base_url="http://theta.jottit.test/") as sess:
+        assert site_id in sess["signed_in_sites"]
+
+
+def test_post_change_password_is_one_shot(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="cp5", public_url="iota")
+    with db_engine.begin() as conn:
+        set_change_pwd_token(conn, site_id=site_id, token="burn-after")
+
+    # First use succeeds.
+    client.post(
+        "/site/change-password",
+        base_url="http://iota.jottit.test/",
+        data={"d": "burn-after", "new_password": "first-pw"},
+    )
+    # Reusing the same token now hits a "no stored token" path and redirects.
+    response = client.post(
+        "/site/change-password",
+        base_url="http://iota.jottit.test/",
+        data={"d": "burn-after", "new_password": "second-pw"},
+    )
+
+    assert response.status_code == 303
+    with db_engine.connect() as conn:
+        site = get_site(conn, site_id=site_id)
+        assert site is not None
+        # Password still reflects the first reset; second attempt didn't take.
+        assert verify_password("first-pw", site.password)
+
+
+def test_post_change_password_with_wrong_token_redirects(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="cp6", public_url="kappa")
+    with db_engine.begin() as conn:
+        set_change_pwd_token(conn, site_id=site_id, token="real-token")
+
+    response = client.post(
+        "/site/change-password",
+        base_url="http://kappa.jottit.test/",
+        data={"d": "wrong-token", "new_password": "nope"},
+    )
+
+    assert response.status_code == 303
+    with db_engine.connect() as conn:
+        site = get_site(conn, site_id=site_id)
+        assert site is not None
+        # Original password and token untouched.
+        assert verify_password("hunter2", site.password)
+        assert site.change_pwd_token == "real-token"
+
+
+def test_post_change_password_rejects_empty_password(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="cp7", public_url="lambda")
+    with db_engine.begin() as conn:
+        set_change_pwd_token(conn, site_id=site_id, token="t")
+
+    response = client.post(
+        "/site/change-password",
+        base_url="http://lambda.jottit.test/",
+        data={"d": "t", "new_password": ""},
+    )
+
+    assert response.status_code == 400
+    with db_engine.connect() as conn:
+        site = get_site(conn, site_id=site_id)
+        assert site is not None
+        # Token is preserved so the user can retry.
+        assert site.change_pwd_token == "t"
+
+
+# ---- End-to-end recovery flow ----
+
+
+def test_end_to_end_recovery_via_emailed_link(
+    client: FlaskClient, db_engine: Engine, app: Flask
+) -> None:
+    """Walk through the full recovery: request reset, follow the emailed URL, set new password."""
+    site_id = _seed_claimed_site(db_engine, secret_url="e2e", public_url="omega", password="old-pw")
+
+    client.post("/site/forgot-password", base_url="http://omega.jottit.test/")
+    body = app.extensions["outbox"].sent[0].body
+
+    match = re.search(r"site/change-password\?d=(\S+)", body)
+    assert match is not None
+    token = match.group(1)
+
+    response = client.post(
+        "/site/change-password",
+        base_url="http://omega.jottit.test/",
+        data={"d": token, "new_password": "new-pw"},
+    )
+
+    assert response.status_code == 303
+    with db_engine.connect() as conn:
+        site = get_site(conn, site_id=site_id)
+        assert site is not None
+        assert verify_password("new-pw", site.password)
+        assert not verify_password("old-pw", site.password)

--- a/tests/test_secret_routing.py
+++ b/tests/test_secret_routing.py
@@ -9,10 +9,8 @@ APEX = "http://jottit.test/"
 @pytest.mark.parametrize(
     ("method", "path", "expected_substring"),
     [
-        # /site/claim is exercised end-to-end in tests/test_claim.py.
-        ("GET", "/abc123/site/signin", "site/signin GET"),
-        ("POST", "/abc123/site/signin", "site/signin POST"),
-        ("POST", "/abc123/site/signout", "site/signout POST"),
+        # /site/claim, /site/signin, /site/signout are exercised end-to-end
+        # in tests/test_claim.py and tests/test_signin.py.
         ("GET", "/abc123/site/forgot-password", "site/forgot-password GET"),
         ("POST", "/abc123/site/forgot-password", "site/forgot-password POST"),
         ("GET", "/abc123/site/change-password", "site/change-password GET"),
@@ -67,7 +65,6 @@ def test_secret_admin_routes(
 @pytest.mark.parametrize(
     ("secret_path", "subdomain_path"),
     [
-        ("/abc123/site/signin", "/site/signin"),
         ("/abc123/admin/settings", "/admin/settings"),
         ("/abc123/admin/design", "/admin/design"),
     ],

--- a/tests/test_secret_routing.py
+++ b/tests/test_secret_routing.py
@@ -9,8 +9,7 @@ APEX = "http://jottit.test/"
 @pytest.mark.parametrize(
     ("method", "path", "expected_substring"),
     [
-        ("GET", "/abc123/site/claim", "site/claim GET"),
-        ("POST", "/abc123/site/claim", "site/claim POST"),
+        # /site/claim is exercised end-to-end in tests/test_claim.py.
         ("GET", "/abc123/site/signin", "site/signin GET"),
         ("POST", "/abc123/site/signin", "site/signin POST"),
         ("POST", "/abc123/site/signout", "site/signout POST"),
@@ -68,7 +67,6 @@ def test_secret_admin_routes(
 @pytest.mark.parametrize(
     ("secret_path", "subdomain_path"),
     [
-        ("/abc123/site/claim", "/site/claim"),
         ("/abc123/site/signin", "/site/signin"),
         ("/abc123/admin/settings", "/admin/settings"),
         ("/abc123/admin/design", "/admin/design"),

--- a/tests/test_secret_routing.py
+++ b/tests/test_secret_routing.py
@@ -9,12 +9,10 @@ APEX = "http://jottit.test/"
 @pytest.mark.parametrize(
     ("method", "path", "expected_substring"),
     [
-        # /site/claim, /site/signin, /site/signout are exercised end-to-end
-        # in tests/test_claim.py and tests/test_signin.py.
-        ("GET", "/abc123/site/forgot-password", "site/forgot-password GET"),
-        ("POST", "/abc123/site/forgot-password", "site/forgot-password POST"),
-        ("GET", "/abc123/site/change-password", "site/change-password GET"),
-        ("POST", "/abc123/site/change-password", "site/change-password POST"),
+        # /site/claim, /site/signin, /site/signout, /site/forgot-password,
+        # and /site/change-password are exercised end-to-end in
+        # tests/test_claim.py, tests/test_signin.py, and
+        # tests/test_password_recovery.py.
         ("GET", "/abc123/site/changes", "site/changes GET"),
         ("GET", "/abc123/site/changes.atom", "site/changes.atom GET"),
         ("POST", "/abc123/site/hide-primer", "site/hide-primer POST"),

--- a/tests/test_signin.py
+++ b/tests/test_signin.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+from sqlalchemy import Engine
+
+from jottit.auth import hash_password
+from jottit.db import claim_site, metadata, new_site
+
+APEX = "http://jottit.test/"
+
+
+@pytest.fixture(autouse=True)
+def _truncate(db_engine: Engine) -> Iterator[None]:
+    yield
+    with db_engine.begin() as conn:
+        for table in reversed(metadata.sorted_tables):
+            conn.execute(table.delete())
+
+
+def _seed_claimed_site(
+    db_engine: Engine,
+    *,
+    secret_url: str,
+    public_url: str | None = None,
+    password: str = "hunter2",
+    email: str = "o@example.com",
+    security: str = "private",
+) -> int:
+    with db_engine.begin() as conn:
+        site_id = new_site(conn, content="hi", secret_url=secret_url, public_url=public_url)
+        claim_site(
+            conn,
+            site_id=site_id,
+            password_hash=hash_password(password),
+            email=email,
+            security=security,
+        )
+    return site_id
+
+
+# ---- GET /site/signin ----
+
+
+def test_get_signin_renders_form(client: FlaskClient, db_engine: Engine) -> None:
+    _seed_claimed_site(db_engine, secret_url="s1", public_url="alpha")
+
+    response = client.get("/site/signin", base_url="http://alpha.jottit.test/")
+
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert 'name="password"' in body
+    assert 'name="return_to"' in body
+
+
+def test_get_signin_redirects_when_site_unclaimed(client: FlaskClient, db_engine: Engine) -> None:
+    with db_engine.begin() as conn:
+        new_site(conn, content="hi", secret_url="s2", public_url="beta")
+
+    response = client.get("/site/signin", base_url="http://beta.jottit.test/")
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/"
+
+
+def test_get_signin_preserves_return_to_in_hidden_field(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_claimed_site(db_engine, secret_url="s3", public_url="gamma")
+
+    response = client.get("/site/signin?return_to=/notes", base_url="http://gamma.jottit.test/")
+
+    assert response.status_code == 200
+    assert 'value="notes"' in response.data.decode()
+
+
+# ---- POST /site/signin ----
+
+
+def test_post_signin_with_correct_password_signs_in_and_redirects(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="s4", public_url="delta")
+
+    response = client.post(
+        "/site/signin",
+        base_url="http://delta.jottit.test/",
+        data={"password": "hunter2", "return_to": ""},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/"
+
+    with client.session_transaction(base_url="http://delta.jottit.test/") as sess:
+        assert site_id in sess["signed_in_sites"]
+
+
+def test_post_signin_redirects_to_return_to(client: FlaskClient, db_engine: Engine) -> None:
+    _seed_claimed_site(db_engine, secret_url="s5", public_url="epsilon")
+
+    response = client.post(
+        "/site/signin",
+        base_url="http://epsilon.jottit.test/",
+        data={"password": "hunter2", "return_to": "notes"},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/notes"
+
+
+def test_post_signin_wrong_password_returns_401(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="s6", public_url="zeta")
+
+    response = client.post(
+        "/site/signin",
+        base_url="http://zeta.jottit.test/",
+        data={"password": "wrong", "return_to": ""},
+    )
+
+    assert response.status_code == 401
+    body = response.data.decode()
+    # Jinja escapes the apostrophe; match the rendered form.
+    assert "doesn" in body and "match" in body
+
+    with client.session_transaction(base_url="http://zeta.jottit.test/") as sess:
+        assert site_id not in sess.get("signed_in_sites", [])
+
+
+def test_post_signin_rejects_open_redirect_via_return_to(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_claimed_site(db_engine, secret_url="s7", public_url="eta")
+
+    response = client.post(
+        "/site/signin",
+        base_url="http://eta.jottit.test/",
+        data={"password": "hunter2", "return_to": "//evil.com/"},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/"
+
+
+def test_post_signin_rejects_absolute_url_in_return_to(
+    client: FlaskClient, db_engine: Engine
+) -> None:
+    _seed_claimed_site(db_engine, secret_url="s8", public_url="theta")
+
+    response = client.post(
+        "/site/signin",
+        base_url="http://theta.jottit.test/",
+        data={"password": "hunter2", "return_to": "https://evil.com/"},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/"
+
+
+# ---- POST /site/signout ----
+
+
+def test_post_signout_clears_session_and_redirects(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="so1", public_url="iota")
+    with client.session_transaction(base_url="http://iota.jottit.test/") as sess:
+        sess["signed_in_sites"] = [site_id]
+
+    response = client.post(
+        "/site/signout",
+        base_url="http://iota.jottit.test/",
+        data={"return_to": ""},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/"
+    with client.session_transaction(base_url="http://iota.jottit.test/") as sess:
+        assert site_id not in sess.get("signed_in_sites", [])
+
+
+def test_post_signout_only_removes_current_site(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="so2", public_url="kappa")
+    other_site_id = 999  # unrelated, simulates a second signed-in site
+    with client.session_transaction(base_url="http://kappa.jottit.test/") as sess:
+        sess["signed_in_sites"] = [site_id, other_site_id]
+
+    client.post(
+        "/site/signout",
+        base_url="http://kappa.jottit.test/",
+        data={"return_to": ""},
+    )
+
+    with client.session_transaction(base_url="http://kappa.jottit.test/") as sess:
+        assert sess["signed_in_sites"] == [other_site_id]
+
+
+def test_post_signout_honors_return_to(client: FlaskClient, db_engine: Engine) -> None:
+    _seed_claimed_site(db_engine, secret_url="so3", public_url="lambda")
+
+    response = client.post(
+        "/site/signout",
+        base_url="http://lambda.jottit.test/",
+        data={"return_to": "about"},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/about"
+
+
+# ---- secret-URL routing ----
+
+
+def test_signin_via_secret_url(client: FlaskClient, db_engine: Engine) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="abc12")
+
+    response = client.post(
+        "/abc12/site/signin",
+        base_url=APEX,
+        data={"password": "hunter2", "return_to": ""},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/abc12/"
+
+    with client.session_transaction(base_url=APEX) as sess:
+        assert site_id in sess["signed_in_sites"]
+
+
+def test_signout_via_secret_url_returns_to_secret_root(
+    client: FlaskClient, db_engine: Engine, app: Flask
+) -> None:
+    site_id = _seed_claimed_site(db_engine, secret_url="abc34")
+    with client.session_transaction(base_url=APEX) as sess:
+        sess["signed_in_sites"] = [site_id]
+
+    response = client.post(
+        "/abc34/site/signout",
+        base_url=APEX,
+        data={"return_to": ""},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "/abc34/"

--- a/tests/test_subdomain_routing.py
+++ b/tests/test_subdomain_routing.py
@@ -9,8 +9,7 @@ SITE_BASE = "http://mysite.jottit.test/"
 @pytest.mark.parametrize(
     ("method", "path", "expected_substring"),
     [
-        ("GET", "/site/claim", "site/claim GET"),
-        ("POST", "/site/claim", "site/claim POST"),
+        # /site/claim is exercised end-to-end in tests/test_claim.py.
         ("GET", "/site/signin", "site/signin GET"),
         ("POST", "/site/signin", "site/signin POST"),
         ("POST", "/site/signout", "site/signout POST"),

--- a/tests/test_subdomain_routing.py
+++ b/tests/test_subdomain_routing.py
@@ -9,10 +9,8 @@ SITE_BASE = "http://mysite.jottit.test/"
 @pytest.mark.parametrize(
     ("method", "path", "expected_substring"),
     [
-        # /site/claim is exercised end-to-end in tests/test_claim.py.
-        ("GET", "/site/signin", "site/signin GET"),
-        ("POST", "/site/signin", "site/signin POST"),
-        ("POST", "/site/signout", "site/signout POST"),
+        # /site/claim, /site/signin, /site/signout are exercised end-to-end
+        # in tests/test_claim.py and tests/test_signin.py.
         ("GET", "/site/forgot-password", "site/forgot-password GET"),
         ("POST", "/site/forgot-password", "site/forgot-password POST"),
         ("GET", "/site/change-password", "site/change-password GET"),

--- a/tests/test_subdomain_routing.py
+++ b/tests/test_subdomain_routing.py
@@ -9,12 +9,10 @@ SITE_BASE = "http://mysite.jottit.test/"
 @pytest.mark.parametrize(
     ("method", "path", "expected_substring"),
     [
-        # /site/claim, /site/signin, /site/signout are exercised end-to-end
-        # in tests/test_claim.py and tests/test_signin.py.
-        ("GET", "/site/forgot-password", "site/forgot-password GET"),
-        ("POST", "/site/forgot-password", "site/forgot-password POST"),
-        ("GET", "/site/change-password", "site/change-password GET"),
-        ("POST", "/site/change-password", "site/change-password POST"),
+        # /site/claim, /site/signin, /site/signout, /site/forgot-password,
+        # and /site/change-password are exercised end-to-end in
+        # tests/test_claim.py, tests/test_signin.py, and
+        # tests/test_password_recovery.py.
         ("GET", "/site/changes", "site/changes GET"),
         ("GET", "/site/changes.atom", "site/changes.atom GET"),
         ("POST", "/site/hide-primer", "site/hide-primer POST"),

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "alembic"
@@ -14,6 +18,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
 ]
 
 [[package]]
@@ -32,6 +79,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -241,6 +345,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "argon2-cffi" },
     { name = "flask" },
     { name = "gunicorn" },
     { name = "markupsafe" },
@@ -262,6 +367,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
+    { name = "argon2-cffi", specifier = ">=23.1" },
     { name = "flask", specifier = ">=3.0" },
     { name = "gunicorn", specifier = ">=21.2" },
     { name = "markupsafe", specifier = ">=2.1" },
@@ -481,6 +587,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
     { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
     { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Step-by-step port of the original site-level auth: password hashing, claim, signin/signout, forgot/change password, and wiring auth guards into the page/draft/admin handlers.
- One commit per sub-step (1-6). PR will grow as commits land.

### Architectural decisions
- **Password hash:** argon2id via argon2-cffi (no compat with the 2007 HMAC scheme — fresh deployment).
- **Sessions:** Flask signed cookie. `session["signed_in_sites"]` is the list of site IDs the visitor is signed in to (one cookie, many sites).
- **Email:** log-only stub in M4; real SMTP arrives in M8 alongside Turnstile / Alembic / Dockerfile / fly.toml.

## Test plan
- [x] Step 1: argon2 hash/verify + DB helpers (`claim_site`, `set_password`, `set_change_pwd_token`, `recover_password`, `update_site`)
- [ ] Step 2: session helpers + auth guard
- [ ] Step 3: `/site/claim`
- [ ] Step 4: `/site/signin` + `/site/signout`
- [ ] Step 5: `/site/forgot-password` + `/site/change-password`
- [ ] Step 6: auth guards on page/draft/admin views; security-level enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)